### PR TITLE
Task/gc storage transfer service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.7-alpine
 MAINTAINER Simon Jupp "jupp@ebi.ac.uk"
 
 RUN apk update && \

--- a/exporter.py
+++ b/exporter.py
@@ -93,8 +93,8 @@ def setup_terra_exporter() -> Thread:
     dcp_staging_client = (DcpStagingClient
                           .Builder()
                           .with_schema_service(schema_service)
-                          .aws_access_key(aws_access_key_id, aws_access_key_secret)
                           .with_gcs_info(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix)
+                          .with_gcs_xfer(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix, aws_access_key_id, aws_access_key_secret)
                           .build())
 
     terra_exporter = TerraExporter(ingest_client, metadata_service, graph_crawler, dcp_staging_client)

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -94,19 +94,14 @@ class GcsXferStorage:
                                                                 "job_names": [job_name]
                                                             }))
             response: Dict = request.execute()
-            if not response.get("operations"):
-                raise Exception(f'No transfer operations for transferJob {job_name}')
-            else:
-                try:
-                    transfer_operations = response["operations"]
-                    transfer_operation = transfer_operations[0]
-                    if transfer_operation.get("done"):
-                        return
-                    else:
-                        time.sleep(wait_time)
-                        return self._assert_file_transferred(job_name, wait_time * 2, time_waited + wait_time, max_wait_time_secs)
-                except (KeyError, IndexError) as e:
-                    raise Exception(f'Failed to parse transferOperations') from e
+            try:
+                if response.get("operations") and len(response["operations"]) > 0 and response["operations"][0].get("done"):
+                    return
+                else:
+                    time.sleep(wait_time)
+                    return self._assert_file_transferred(job_name, wait_time * 2, time_waited + wait_time, max_wait_time_secs)
+            except (KeyError, IndexError) as e:
+                raise Exception(f'Failed to parse transferOperations') from e
 
     def create_transfer_client(self):
         return googleapiclient.discovery.build('storagetransfer', 'v1', credentials=self.credentials, cache_discovery=False)

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -1,0 +1,119 @@
+import googleapiclient.discovery
+from dataclasses import dataclass
+from typing import Dict
+from exporter.metadata import DataFile
+from datetime import datetime
+import json
+import time
+from google.oauth2.service_account import Credentials
+
+
+@dataclass
+class TransferJobSpec:
+    name: str
+    description: str
+    project_id: str
+    source_bucket: str
+    source_key: str
+    dest_bucket: str
+    aws_access_key_id: str
+    aws_access_key_secret: str
+
+    def to_dict(self) -> Dict:
+        start_date = datetime.now()
+        return {
+            'description': self.description,
+            'status': 'ENABLED',
+            'projectId': self.project_id,
+            'schedule': {
+                'scheduleStartDate': {
+                    'day': start_date.day,
+                    'month': start_date.month,
+                    'year': start_date.year
+                },
+                'scheduleEndDate': {
+                    'day': start_date.day,
+                    'month': start_date.month,
+                    'year': start_date.year
+                }
+            },
+            'transferSpec': {
+                'awsS3DataSource': {
+                    'bucketName': self.source_bucket,
+                    'awsAccessKey': {
+                        'accessKeyId': self.aws_access_key_id,
+                        'secretAccessKey': self.aws_access_key_secret
+                    }
+                },
+                'gcsDataSink': {
+                    'bucketName': self.dest_bucket
+                },
+                'objectConditions': {
+                    'includePrefixes': [self.source_key]
+                }
+            }
+        }
+
+
+class GcsXferStorage:
+
+    def __init__(self, aws_access_key_id: str, aws_access_key_secret: str, project_id: str, gcs_dest_bucket: str, gcs_dest_prefix: str, credentials: Credentials):
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_access_key_secret = aws_access_key_secret
+        self.project_id = project_id
+        self.gcs_dest_bucket = gcs_dest_bucket
+        self.gcs_bucket_prefix = gcs_dest_prefix
+        self.credentials = credentials
+
+        self.client = self.create_transfer_client()
+
+    def transfer(self,  data_file: DataFile):
+        transfer_job = self.create_transfer_job(data_file)
+        job_name = self.client.transferJobs().create(body=transfer_job.to_dict()).execute()["name"]
+        self.assert_file_transferred(job_name)
+
+    def assert_file_transferred(self, job_name):
+        two_seconds = 2
+        one_hour_in_seconds = 60 * 60
+        return self._assert_file_transferred(job_name, two_seconds, 0, one_hour_in_seconds)
+
+    def _assert_file_transferred(self, job_name: str, wait_time: int, time_waited: int, max_wait_time_secs: int):
+        if time_waited > max_wait_time_secs:
+            raise Exception(f'Timeout waiting for transfer job to success for job {job_name}')
+        else:
+            request = self.client.transferOperations().list(name="transferOperations",
+                                                            filter=json.dumps({
+                                                                "project_id": self.project_id,
+                                                                "job_names": [job_name]
+                                                            }))
+            response: Dict = request.execute()
+            if not response.get("operations"):
+                raise Exception(f'No transfer operations for transferJob {job_name}')
+            else:
+                try:
+                    transfer_operations = response["operations"]
+                    transfer_operation = transfer_operations[0]
+                    if transfer_operation.get("done"):
+                        return
+                    else:
+                        time.sleep(wait_time)
+                        return self._assert_file_transferred(job_name, wait_time * 2, time_waited + wait_time, max_wait_time_secs)
+                except (KeyError, IndexError) as e:
+                    raise Exception(f'Failed to parse transferOperations') from e
+
+    def create_transfer_client(self):
+        return googleapiclient.discovery.build('storagetransfer', 'v1', credentials=self.credentials)
+
+    @staticmethod
+    def transfer_job_name(data_file: DataFile) -> str:
+        return data_file.checksums.sha256
+
+    def create_transfer_job(self, data_file: DataFile) -> TransferJobSpec:
+        return TransferJobSpec(name=self.transfer_job_name(data_file),
+                               description=f'HCA data-file: {data_file.uuid}',
+                               project_id=self.project_id,
+                               source_bucket=data_file.source_bucket(),
+                               source_key=data_file.source_key(),
+                               dest_bucket=self.gcs_dest_bucket,
+                               aws_access_key_id=self.aws_access_key_id,
+                               aws_access_key_secret=self.aws_access_key_secret)

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -1,11 +1,18 @@
 import googleapiclient.discovery
-from dataclasses import dataclass
-from typing import Dict
+from typing import IO, Dict, Any, Union
 from exporter.metadata import DataFile
 from datetime import datetime
-import json
 import time
+
+from google.cloud import storage
 from google.oauth2.service_account import Credentials
+from google.api_core.exceptions import PreconditionFailed
+import json
+import logging
+from io import StringIO, BufferedReader
+
+from time import sleep
+from dataclasses import dataclass
 
 
 @dataclass
@@ -117,3 +124,84 @@ class GcsXferStorage:
                                dest_bucket=self.gcs_dest_bucket,
                                aws_access_key_id=self.aws_access_key_id,
                                aws_access_key_secret=self.aws_access_key_secret)
+
+
+class UploadPollingException(Exception):
+    pass
+
+
+Streamable = Union[BufferedReader, StringIO, IO[Any]]
+
+
+class GcsStorage:
+    def __init__(self, gcs_client: storage.Client, bucket_name: str, storage_prefix: str):
+        self.gcs_client = gcs_client
+        self.bucket_name = bucket_name
+        self.storage_prefix = storage_prefix
+
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(logging.INFO)
+
+    def file_exists(self, object_key: str) -> bool:
+        dest_key = f'{self.storage_prefix}/{object_key}'
+        staging_bucket: storage.Bucket = self.gcs_client.bucket(self.bucket_name)
+        blob: storage.Blob = staging_bucket.blob(dest_key)
+        if not blob.exists():
+            return False
+        else:
+            blob.reload()
+            return blob.metadata is not None and blob.metadata.get("export_completed", False)
+
+    def write(self, object_key: str, data_stream: Streamable):
+        try:
+            dest_key = f'{self.storage_prefix}/{object_key}'
+            staging_bucket: storage.Bucket = self.gcs_client.bucket(self.bucket_name)
+            blob: storage.Blob = staging_bucket.blob(dest_key, chunk_size=1024 * 256 * 20)
+
+            if not blob.exists():
+                blob.upload_from_file(data_stream, if_generation_match=0)
+                blob.metadata = {"export_completed": True}
+                blob.patch()
+            else:
+                self.assert_file_uploaded(object_key)
+        except PreconditionFailed as e:
+            # With if_generation_match=0, this pre-condition failure indicates that another
+            # export instance has began uploading this file. We should not attempt to upload
+            # and instead poll for its completion
+            self.assert_file_uploaded(object_key)
+
+    def move_file(self, source_key: str, object_key: str):
+        dest_key = f'{self.storage_prefix}/{object_key}'
+        staging_bucket: storage.Bucket = self.gcs_client.bucket(self.bucket_name)
+        source_blob: storage.Blob = staging_bucket.blob(source_key)
+
+        new_blob = staging_bucket.rename_blob(source_blob, dest_key)
+        new_blob.metadata = {"export_completed": True}
+        new_blob.patch()
+        return
+
+    def assert_file_uploaded(self, object_key: str):
+        dest_key = f'{self.storage_prefix}/{object_key}'
+        staging_bucket: storage.Bucket = self.gcs_client.bucket(self.bucket_name)
+        blob = staging_bucket.blob(dest_key)
+
+        one_hour_in_seconds = 60 * 60
+        one_hundred_milliseconds = 0.1
+        return self._assert_file_uploaded(blob, one_hundred_milliseconds, one_hour_in_seconds)
+
+    def _assert_file_uploaded(self, blob: storage.Blob, sleep_time: float, max_sleep_time: float):
+        if sleep_time > max_sleep_time:
+            raise UploadPollingException(f'Could not verify completed upload for blob {blob.name} within maximum '
+                                         f'wait time of {str(max_sleep_time)} seconds')
+        else:
+            sleep(sleep_time)
+            blob.reload()
+
+            export_completed = blob.metadata is not None and blob.metadata.get("export_completed")
+            if export_completed:
+                return
+            else:
+                new_sleep_time = sleep_time * 2
+                self.logger.info(f'Verifying upload of blob {blob.name}. Waiting for {str(new_sleep_time)} seconds...')
+                return self._assert_file_uploaded(blob, new_sleep_time, max_sleep_time)
+

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -216,7 +216,7 @@ class GcsStorage:
         patch_retryer = retry.Retry(predicate=retry.if_exception_type(ServiceUnavailable),
                                     deadline=60)
 
-        patch_retryer(lambda: blob.patch())
+        patch_retryer(lambda: blob.patch())()
 
     def assert_file_uploaded(self, object_key: str):
         dest_key = f'{self.storage_prefix}/{object_key}'

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -97,11 +97,6 @@ class GcsXferStorage:
                                aws_access_key_id=self.aws_access_key_id,
                                aws_access_key_secret=self.aws_access_key_secret)
 
-    def transfer(self,  data_file: DataFile):
-        transfer_job = self.create_transfer_job(data_file)
-        job_name = self.client.transferJobs().create(body=transfer_job.to_dict()).execute()["name"]
-        self.assert_job_complete(job_name)
-
     def assert_job_complete(self, job_name):
         two_seconds = 2
         three_hours_in_seconds = 60 * 60 * 3
@@ -128,20 +123,6 @@ class GcsXferStorage:
 
     def create_transfer_client(self):
         return googleapiclient.discovery.build('storagetransfer', 'v1', credentials=self.credentials, cache_discovery=False)
-
-    @staticmethod
-    def transfer_job_name(data_file: DataFile) -> str:
-        return f'transferJobs/{data_file.checksums.sha256}'
-
-    def create_transfer_job(self, data_file: DataFile) -> TransferJobSpec:
-        return TransferJobSpec(name=self.transfer_job_name(data_file),
-                               description=f'HCA data-file: {data_file.uuid}',
-                               project_id=self.project_id,
-                               source_bucket=data_file.source_bucket(),
-                               source_key=data_file.source_key(),
-                               dest_bucket=self.gcs_dest_bucket,
-                               aws_access_key_id=self.aws_access_key_id,
-                               aws_access_key_secret=self.aws_access_key_secret)
 
 
 class UploadPollingException(Exception):

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -109,7 +109,7 @@ class GcsXferStorage:
                     raise Exception(f'Failed to parse transferOperations') from e
 
     def create_transfer_client(self):
-        return googleapiclient.discovery.build('storagetransfer', 'v1', credentials=self.credentials)
+        return googleapiclient.discovery.build('storagetransfer', 'v1', credentials=self.credentials, cache_discovery=False)
 
     @staticmethod
     def transfer_job_name(data_file: DataFile) -> str:

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -75,6 +75,8 @@ class GcsXferStorage:
         self.credentials = credentials
 
         self.client = self.create_transfer_client()
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(logging.INFO)
 
     def transfer_upload_area(self, source_bucket: str, upload_area_key: str, export_job_id: str):
         transfer_job = self.transfer_job_for_upload_area(source_bucket, upload_area_key, export_job_id)
@@ -116,6 +118,8 @@ class GcsXferStorage:
                 if response.get("operations") and len(response["operations"]) > 0 and response["operations"][0].get("done"):
                     return
                 else:
+                    self.logger.info(f'Awaiting complete transfer for job {job_name}. Waiting {str(wait_time)} seconds.'
+                                     f'(total time waited: {str(time_waited)}, max wait time: {str(max_wait_time_secs)} seconds)')
                     time.sleep(wait_time)
                     return self._assert_job_complete(job_name, wait_time * 2, time_waited + wait_time, max_wait_time_secs)
             except (KeyError, IndexError) as e:

--- a/exporter/terra/terra_exporter.py
+++ b/exporter/terra/terra_exporter.py
@@ -16,9 +16,12 @@ class TerraExporter:
         self.graph_crawler = graph_crawler
         self.dcp_staging_client = dcp_staging_client
 
-    def export(self, process_uuid, experiment_uuid, experiment_version):
+    def export(self, process_uuid, submission_uuid, experiment_uuid, experiment_version, export_job_id):
+        submission = self.get_submission(submission_uuid)
         process = self.get_process(process_uuid)
         project = self.project_for_process(process)
+
+        self.dcp_staging_client.transfer_data_files(submission, export_job_id)
 
         experiment_graph = self.graph_crawler.generate_experiment_graph(process, project)
         experiment_data_files = [DataFile.from_file_metadata(m) for m in experiment_graph.nodes.get_nodes() if m.metadata_type == "file"]

--- a/exporter/terra/terra_listener.py
+++ b/exporter/terra/terra_listener.py
@@ -101,7 +101,7 @@ class _TerraListener(ConsumerProducerMixin):
         try:
             exp = ExperimentMessage.from_dict(json.loads(body))
             self.logger.info(f'Received experiment message for process {exp.process_uuid} (index {exp.experiment_index} for submission {exp.submission_uuid})')
-            self.terra_exporter.export(exp.process_uuid, exp.experiment_uuid, exp.experiment_version)
+            self.terra_exporter.export(exp.process_uuid, exp.submission_uuid, exp.experiment_uuid, exp.experiment_version, exp.job_id)
             self.logger.info(f'Exported experiment for process uuid {exp.process_uuid} (--index {exp.experiment_index} --total {exp.total} --submission {exp.submission_uuid})')
             self.log_complete_assay(exp.job_id, exp.process_id)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ boto3-stubs[s3]
 cachetools
 -e git+https://github.com/HumanCellAtlas/ingest-client.git@74472037#egg=hca_ingest
 smart_open[all]
+google-api-python-client


### PR DESCRIPTION
Using the google cloud transfer for moving files from S3 to GCS. This sidesteps moving the files through the kubernetes network, which can deny service to other parts of the ingest system