### PR TITLE
Mirror terra staging area

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -84,6 +84,7 @@ def setup_terra_exporter() -> Thread:
     gcs_svc_credentials_path = os.environ['GCP_SVC_ACCOUNT_KEY_PATH']
     gcp_project = os.environ['GCP_PROJECT']
     terra_bucket_name = os.environ['TERRA_BUCKET_NAME']
+    ingest_terra_bucket_name = os.environ['INGEST_TERRA_BUCKET_NAME']
     terra_bucket_prefix = os.environ['TERRA_BUCKET_PREFIX']
 
     ingest_client = IngestApi(ingest_api_url)
@@ -95,6 +96,7 @@ def setup_terra_exporter() -> Thread:
                           .with_schema_service(schema_service)
                           .with_gcs_info(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix)
                           .with_gcs_xfer(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix, aws_access_key_id, aws_access_key_secret)
+                          .with_aws_info(aws_access_key_id, aws_access_key_secret, ingest_terra_bucket_name)
                           .build())
 
     terra_exporter = TerraExporter(ingest_client, metadata_service, graph_crawler, dcp_staging_client)

--- a/exporter.py
+++ b/exporter.py
@@ -96,7 +96,7 @@ def setup_terra_exporter() -> Thread:
                           .with_schema_service(schema_service)
                           .with_gcs_info(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix)
                           .with_gcs_xfer(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix, aws_access_key_id, aws_access_key_secret)
-                          .with_aws_info(aws_access_key_id, aws_access_key_secret, ingest_terra_bucket_name)
+                          .with_aws_info(aws_access_key_id, aws_access_key_secret, ingest_terra_bucket_name, terra_bucket_prefix)
                           .build())
 
     terra_exporter = TerraExporter(ingest_client, metadata_service, graph_crawler, dcp_staging_client)

--- a/exporter/terra/aws.py
+++ b/exporter/terra/aws.py
@@ -5,31 +5,40 @@ from botocore.exceptions import ClientError
 
 
 class AwsStorage:
-    def __init__(self, session: Session, bucket_name: str, storage_prefix: str):
+    def __init__(self, session: Session, bucket_name: str, storage_prefix: str = None):
         self.session = session
         self.client = self.session.client('s3')
         self.bucket_name = bucket_name
         self.storage_prefix = storage_prefix
 
     def write_json(self, key: str, json_data: dict):
-        dest_key = f'{self.storage_prefix}/{key}'
-        self.client.put_object(Bucket=bucket_name, Key=dest_key,
+        if self.storage_prefix:
+            key = f'{self.storage_prefix}/{key}'
+
+        self.client.put_object(Bucket=self.bucket_name, Key=key,
                                Body=json.dumps(json_data, indent=2),
                                ContentType='application/json')
 
     def copy_file(self, source_bucket, source_key, dest_key):
         dest_bucket = self.bucket_name
-        dest_key = f'{self.storage_prefix}/{dest_key}'
+
+        if self.storage_prefix:
+            dest_key = f'{self.storage_prefix}/{dest_key}'
+
         copy_source = {
             'Bucket': source_bucket,
             'Key': source_key
         }
-        self.client.copy(copy_source, dest_bucket, dest_key)
-
-    def file_exists(self, bucket, key) -> bool:
         try:
-            self.client.head_object(Bucket=bucket, Key=key)
-            return True
+            self.client.copy(copy_source, dest_bucket, dest_key)
+        except Exception as e:
+            raise
+
+    def file_exists(self, key) -> bool:
+        try:
+            self.client.head_object(Bucket=self.bucket_name, Key=key)
         except ClientError as error:
             if error.response['Error']['Code'] != '404':
-                return False
+                raise
+            return False
+        return True

--- a/exporter/terra/aws.py
+++ b/exporter/terra/aws.py
@@ -24,7 +24,6 @@ class AwsStorage:
             'Bucket': source_bucket,
             'Key': source_key
         }
-
         self.client.copy(copy_source, dest_bucket, dest_key)
 
     def file_exists(self, bucket, key) -> bool:

--- a/exporter/terra/aws.py
+++ b/exporter/terra/aws.py
@@ -1,0 +1,36 @@
+from boto3 import Session
+import json
+
+from botocore.exceptions import ClientError
+
+
+class AwsStorage:
+    def __init__(self, session: Session, bucket_name: str, storage_prefix: str):
+        self.session = session
+        self.client = self.session.client('s3')
+        self.bucket_name = bucket_name
+        self.storage_prefix = storage_prefix
+
+    def write_json(self, key: str, json_data: dict):
+        dest_key = f'{self.storage_prefix}/{key}'
+        self.client.put_object(Bucket=bucket_name, Key=dest_key,
+                               Body=json.dumps(json_data, indent=2),
+                               ContentType='application/json')
+
+    def copy_file(self, source_bucket, source_key, dest_key):
+        dest_bucket = self.bucket_name
+        dest_key = f'{self.storage_prefix}/{dest_key}'
+        copy_source = {
+            'Bucket': source_bucket,
+            'Key': source_key
+        }
+
+        self.client.copy(copy_source, dest_bucket, dest_key)
+
+    def file_exists(self, bucket, key) -> bool:
+        try:
+            self.client.head_object(Bucket=bucket, Key=key)
+            return True
+        except ClientError as error:
+            if error.response['Error']['Code'] != '404':
+                return False

--- a/exporter/terra/dcp_staging_client.py
+++ b/exporter/terra/dcp_staging_client.py
@@ -77,8 +77,7 @@ class DcpStagingClient:
         dest_object_key = f'{project_uuid}/metadata/{metadata.concrete_type()}/{metadata.uuid}_{metadata.dcp_version}.json'
 
         metadata_json = metadata.get_content(with_provenance=True)
-        data_stream = DcpStagingClient.dict_to_json_stream(metadata_json)
-        self.write_to_staging_bucket(dest_object_key, data_stream)
+        self.write_json(dest_object_key, metadata_json)
 
         if metadata.metadata_type == "file":
             self.write_file_descriptor(metadata, project_uuid)
@@ -86,14 +85,12 @@ class DcpStagingClient:
     def write_links(self, link_set: LinkSet, experiment_uuid: str, experiment_version: str, project_uuid: str):
         dest_object_key = f'{project_uuid}/links/{experiment_uuid}_{experiment_version}_{project_uuid}.json'
         links_json = self.generate_links_json(link_set)
-        data_stream = DcpStagingClient.dict_to_json_stream(links_json)
-        self.write_to_staging_bucket(dest_object_key, data_stream)
+        self.write_json(dest_object_key, links_json)
 
     def write_file_descriptor(self, file_metadata: MetadataResource, project_uuid: str):
         dest_object_key = f'{project_uuid}/descriptors/{file_metadata.concrete_type()}/{file_metadata.uuid}_{file_metadata.dcp_version}.json'
         file_descriptor_json = self.generate_file_desciptor_json(file_metadata)
-        data_stream = DcpStagingClient.dict_to_json_stream(file_descriptor_json)
-        self.write_to_staging_bucket(dest_object_key, data_stream)
+        self.write_json(dest_object_key, file_descriptor_json)
 
     def generate_file_desciptor_json(self, file_metadata) -> Dict:
         latest_file_descriptor_schema = self.schema_service.cached_latest_file_descriptor_schema()
@@ -116,7 +113,8 @@ class DcpStagingClient:
         else:
             self.gcs_storage.move_file(data_file.source_key(), dest_object_key)
 
-    def write_to_staging_bucket(self, object_key: str, data_stream: Streamable):
+    def write_json(self, object_key: str, metadata_json: dict):
+        data_stream = DcpStagingClient.dict_to_json_stream(metadata_json)
         self.gcs_storage.write(object_key, data_stream)
 
     def generate_links_json(self, link_set: LinkSet) -> Dict:

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -95,12 +95,13 @@ class GcsXferStorage:
             else:
                 raise
 
-    def sync_to_terra(self, source_bucket: str, project_uuid: str, export_job_id: str):
+    def sync_to_terra(self, source_bucket: str, source_bucket_prefix: str, project_uuid: str, export_job_id: str):
+        source_key = f'{source_bucket_prefix}/{project_uuid}'
         transfer_job = TransferJobSpec(name=f'transferJobs/{export_job_id}',
                                        description=f'Transfer job for ingest terra staging area {project_uuid} and export-job-id {export_job_id}',
                                        project_id=self.gcp_project_id,
                                        source_bucket=source_bucket,
-                                       source_key=project_uuid,
+                                       source_key=source_key,
                                        dest_bucket=self.gcs_dest_bucket,
                                        aws_access_key_id=self.aws_access_key_id,
                                        aws_access_key_secret=self.aws_access_key_secret)

--- a/exporter/terra/terra_export_job.py
+++ b/exporter/terra/terra_export_job.py
@@ -66,12 +66,13 @@ class TerraExportJobService:
         create_export_entity_url = self.get_export_entities_url(job_id)
         requests.post(create_export_entity_url, json.dumps(assay_export_entity.to_dict()),
                       headers={"Content-type": "application/json"}, json=True).raise_for_status()
-        self._maybe_complete_job(job_id)
 
-    def _maybe_complete_job(self, job_id):
+    def maybe_complete_job(self, job_id):
         export_job = self.get_job(job_id)
         if export_job.num_expected_assays == self.get_num_complete_entities_for_job(job_id):
             self.complete_job(job_id)
+            return True
+        return False
 
     def complete_job(self, job_id: str):
         job_url = self.get_job_url(job_id)

--- a/exporter/terra/terra_exporter.py
+++ b/exporter/terra/terra_exporter.py
@@ -27,6 +27,7 @@ class TerraExporter:
         self.dcp_staging_client.write_links(experiment_graph.links, experiment_uuid, experiment_version, project.uuid)
         self.dcp_staging_client.write_data_files(experiment_data_files, project.uuid)
 
+        # FIXME should only get triggered once per submission / project and not per assay
         self.dcp_staging_client.sync_to_terra(project.uuid, export_job_id)
 
     def export_update(self, metadata_urls: Iterable[str]):

--- a/exporter/terra/terra_exporter.py
+++ b/exporter/terra/terra_exporter.py
@@ -17,11 +17,8 @@ class TerraExporter:
         self.dcp_staging_client = dcp_staging_client
 
     def export(self, process_uuid, submission_uuid, experiment_uuid, experiment_version, export_job_id):
-        submission = self.get_submission(submission_uuid)
         process = self.get_process(process_uuid)
         project = self.project_for_process(process)
-
-        self.dcp_staging_client.transfer_data_files(submission, export_job_id)
 
         experiment_graph = self.graph_crawler.generate_experiment_graph(process, project)
         experiment_data_files = [DataFile.from_file_metadata(m) for m in experiment_graph.nodes.get_nodes() if m.metadata_type == "file"]
@@ -29,6 +26,8 @@ class TerraExporter:
         self.dcp_staging_client.write_metadatas(experiment_graph.nodes.get_nodes(), project.uuid)
         self.dcp_staging_client.write_links(experiment_graph.links, experiment_uuid, experiment_version, project.uuid)
         self.dcp_staging_client.write_data_files(experiment_data_files, project.uuid)
+
+        self.dcp_staging_client.sync_to_terra(project.uuid, export_job_id)
 
     def export_update(self, metadata_urls: Iterable[str]):
         metadata_to_update = [self.metadata_service.fetch_resource(url) for url in metadata_urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ cachetools
 -e git+https://github.com/HumanCellAtlas/ingest-client.git@74472037#egg=hca_ingest
 smart_open[all]
 google-api-python-client
+botocore


### PR DESCRIPTION
**Manual changes**:
1. Create an s3 bucket, bucket name: `hca-ingest-terra-staging-area-dev`
1. Create new policy to update the bucket, policy name: `hca-ingest-terra-staging-area-dev-access` 
    ```
    {
        "Version": "2012-10-17",
        "Statement": [
            {
                "Sid": "1",
                "Effect": "Allow",
                "Action": [
                    "s3:GetObject",
                    "s3:ListBucket",
                    "s3:GetBucketLocation",
                    "s3:PutObject"
                ],
                "Resource": [
                    "arn:aws:s3:::hca-ingest-terra-staging-area-dev/*",
                    "arn:aws:s3:::hca-ingest-terra-staging-area-dev"
                ]
            }
        ]
    }
    ```
1. Attach policy to current exporter user: `arn:aws:iam::871979166454:user/hca-ingest-exporter-dev`
1. Update the exporter deployment.yaml in ingest-kube-deployment repo https://github.com/ebi-ait/ingest-kube-deployment/pull/14/files 

