### PR TITLE
Post sub updates

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -36,11 +36,15 @@ UPDATE_QUEUE_TERRA = 'ingest.terra.updates.new'
 
 ASSAY_ROUTING_KEY = 'ingest.assay.manifest.submitted'
 EXPERIMENT_ROUTING_KEY = 'ingest.assay.experiment.submitted'
+DATA_ROUTING_KEY = 'ingest.assay.data.submitted'
+
 UPDATE_ROUTING_KEY = 'ingest.update.experiment.submitted'
 ANALYSIS_ROUTING_KEY = 'ingest.bundle.analysis.submitted'
 
 ASSAY_COMPLETED_ROUTING_KEY = 'ingest.assay.manifest.completed'
 EXPERIMENT_COMPLETED_ROUTING_KEY = 'ingest.assay.experiment.exported'
+
+GCS_TRANSFER_SVC_NOTIFICATION_TOPIC = 'ingest/terra/exportJobs'
 
 
 RETRY_POLICY = {
@@ -92,6 +96,7 @@ def setup_terra_exporter() -> Thread:
     graph_crawler = GraphCrawler(metadata_service)
     dcp_staging_client = (DcpStagingClient
                           .Builder()
+                          .with_ingest_client(ingest_client)
                           .with_schema_service(schema_service)
                           .with_gcs_info(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix)
                           .with_gcs_xfer(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix, aws_access_key_id, aws_access_key_secret)
@@ -104,10 +109,11 @@ def setup_terra_exporter() -> Thread:
     rabbit_port = int(os.environ.get('RABBIT_PORT', '5672'))
     amqp_conn_config = AmqpConnConfig(rabbit_host, rabbit_port)
     experiment_queue_config = QueueConfig(EXPERIMENT_QUEUE_TERRA, EXPERIMENT_ROUTING_KEY, EXCHANGE, EXCHANGE_TYPE, False, None)
+    data_queue_config = QueueConfig(EXPERIMENT_QUEUE_TERRA, DATA_ROUTING_KEY, EXCHANGE, EXCHANGE_TYPE, False, None)
     update_queue_config = QueueConfig(UPDATE_QUEUE_TERRA, UPDATE_ROUTING_KEY, EXCHANGE, EXCHANGE_TYPE, False, None)
     publish_queue_config = QueueConfig(None, EXPERIMENT_COMPLETED_ROUTING_KEY, EXCHANGE, EXCHANGE_TYPE, True, RETRY_POLICY)
 
-    terra_listener = TerraListener(amqp_conn_config, terra_exporter, terra_job_service, experiment_queue_config, update_queue_config, publish_queue_config)
+    terra_listener = TerraListener(amqp_conn_config, terra_exporter, terra_job_service, experiment_queue_config, data_queue_config, update_queue_config, publish_queue_config)
 
     terra_exporter_listener_process = Thread(target=lambda: terra_listener.run())
     terra_exporter_listener_process.start()

--- a/exporter.py
+++ b/exporter.py
@@ -44,8 +44,6 @@ ANALYSIS_ROUTING_KEY = 'ingest.bundle.analysis.submitted'
 ASSAY_COMPLETED_ROUTING_KEY = 'ingest.assay.manifest.completed'
 EXPERIMENT_COMPLETED_ROUTING_KEY = 'ingest.assay.experiment.exported'
 
-GCS_TRANSFER_SVC_NOTIFICATION_TOPIC = 'ingest/terra/exportJobs'
-
 
 RETRY_POLICY = {
     'interval_start': 0,
@@ -89,6 +87,8 @@ def setup_terra_exporter() -> Thread:
     gcp_project = os.environ['GCP_PROJECT']
     terra_bucket_name = os.environ['TERRA_BUCKET_NAME']
     terra_bucket_prefix = os.environ['TERRA_BUCKET_PREFIX']
+    gcs_notification_topic = os.environ['TERRA_GCS_NOTIFICATION_TOPIC']
+    gcs_notification_sub = os.environ['TERRA_GCS_NOTIFICATION_SUB']
 
     ingest_client = IngestApi(ingest_api_url)
     metadata_service = MetadataService(ingest_client)
@@ -99,7 +99,7 @@ def setup_terra_exporter() -> Thread:
                           .with_ingest_client(ingest_client)
                           .with_schema_service(schema_service)
                           .with_gcs_info(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix)
-                          .with_gcs_xfer(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix, aws_access_key_id, aws_access_key_secret)
+                          .with_gcs_xfer(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix, aws_access_key_id, aws_access_key_secret, gcs_notification_topic)
                           .build())
 
     terra_exporter = TerraExporter(ingest_client, metadata_service, graph_crawler, dcp_staging_client)

--- a/exporter/terra/dcp_staging_client.py
+++ b/exporter/terra/dcp_staging_client.py
@@ -72,11 +72,17 @@ class DcpStagingClient:
 
     def write_metadata(self, metadata: MetadataResource, project_uuid: str):
 
+        # TODO1: only proceed if lastContentModified > last
+
         dest_object_key = f'{project_uuid}/metadata/{metadata.concrete_type()}/{metadata.uuid}_{metadata.dcp_version}.json'
 
         metadata_json = metadata.get_content(with_provenance=True)
         data_stream = DcpStagingClient.dict_to_json_stream(metadata_json)
         self.write_to_staging_bucket(dest_object_key, data_stream)
+
+        # TODO2: patch dcpVersion        
+        #patch_url = metadata.metadata_json['_links']['self']['href']
+        #self.ingest_client.patch(patch_url, {"dcpVersion": metadata.dcp_version})
 
         if metadata.metadata_type == "file":
             self.write_file_descriptor(metadata, project_uuid)
@@ -143,11 +149,11 @@ class DcpStagingClient:
 
                 return self
 
-        def with_gcs_xfer(self, service_account_credentials_path: str, gcp_project: str, bucket_name: str, bucket_prefix: str, aws_access_key_id: str, aws_access_key_secret: str, gcs_notif_topic: str):
+        def with_gcs_xfer(self, service_account_credentials_path: str, gcp_project: str, bucket_name: str, bucket_prefix: str, aws_access_key_id: str, aws_access_key_secret: str, gcs_notification_topic: str):
             with open(service_account_credentials_path) as source:
                 info = json.load(source)
                 credentials: Credentials = Credentials.from_service_account_info(info)
-                self.gcs_xfer = GcsXferStorage(aws_access_key_id, aws_access_key_secret, gcp_project, bucket_name, bucket_prefix, credentials, gcs_notif_topic)
+                self.gcs_xfer = GcsXferStorage(aws_access_key_id, aws_access_key_secret, gcp_project, bucket_name, bucket_prefix, credentials, gcs_notification_topic)
 
                 return self
 

--- a/exporter/terra/dcp_staging_client.py
+++ b/exporter/terra/dcp_staging_client.py
@@ -61,10 +61,10 @@ class DcpStagingClient:
         self.schema_service = schema_service
         self.ingest_client = ingest_client
 
-    def transfer_data_files(self, submission: Dict, export_job_id: str):
+    def transfer_data_files(self, submission: Dict, project_uuid, export_job_id: str):
         upload_area = submission["stagingDetails"]["stagingAreaLocation"]["value"]
         bucket_and_key = self.bucket_and_key_for_upload_area(upload_area)
-        self.gcs_xfer.transfer_upload_area(bucket_and_key[0], bucket_and_key[1], export_job_id)
+        self.gcs_xfer.transfer_upload_area(bucket_and_key[0], bucket_and_key[1], project_uuid, export_job_id)
 
     def write_metadatas(self, metadatas: Iterable[MetadataResource], project_uuid: str):
         for metadata in metadatas:

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -24,11 +24,12 @@ class TransferJobSpec:
     description: str
     project_id: str
     source_bucket: str
-    upload_area: str
-    dest_bucket: str
+    source_path: str
     aws_access_key_id: str
     aws_access_key_secret: str
-    gcs_notif_topic: str
+    dest_bucket: str
+    dest_path: str
+    gcs_notification_topic: str
 
     def to_dict(self) -> Dict:
         start_date = datetime.now()
@@ -56,19 +57,18 @@ class TransferJobSpec:
                         'accessKeyId': self.aws_access_key_id,
                         'secretAccessKey': self.aws_access_key_secret
                     },
-                    'path': self.upload_area + '/'
+                    'path': self.source_path + '/'
                 },
                 'gcsDataSink': {
                     'bucketName': self.dest_bucket,
-                    'path': self.upload_area + '/data/'
+                    'path': self.dest_path + '/'
                 },
                 'transferOptions': {
                     'overwriteObjectsAlreadyExistingInSink': False
                 }
             }#,
             #'notificationConfig': {
-            #    'pubsubTopic': self.gcs_notif_topic,
-            #    'eventTypes': ['TRANSFER_OPERATION_SUCCESS', 'TRANSFER_OPERATION_FAILED', 'TRANSFER_OPERATION_ABORTED'],
+            #    'pubsubTopic': self.gcs_notification_topic,
             #    'payloadFormat': 'JSON'
             #}
         }
@@ -76,21 +76,22 @@ class TransferJobSpec:
 
 class GcsXferStorage:
 
-    def __init__(self, aws_access_key_id: str, aws_access_key_secret: str, project_id: str, gcs_dest_bucket: str, gcs_dest_prefix: str, credentials: Credentials, gcs_notif_topic: str):
+    def __init__(self, aws_access_key_id: str, aws_access_key_secret: str, project_id: str, gcs_dest_bucket: str, gcs_dest_prefix: str, credentials: Credentials, gcs_notification_topic: str):
         self.aws_access_key_id = aws_access_key_id
         self.aws_access_key_secret = aws_access_key_secret
         self.project_id = project_id
         self.gcs_dest_bucket = gcs_dest_bucket
         self.gcs_bucket_prefix = gcs_dest_prefix
         self.credentials = credentials
-        self.gcs_notif_topic = gcs_notif_topic
+        self.gcs_notification_topic = gcs_notification_topic
 
         self.client = self.create_transfer_client()
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.INFO)
 
-    def transfer_upload_area(self, source_bucket: str, upload_area_key: str, export_job_id: str):
-        transfer_job = self.transfer_job_for_upload_area(source_bucket, upload_area_key, export_job_id)
+    def transfer_upload_area(self, source_bucket: str, upload_area_key: str, project_uuid: str, export_job_id: str):
+        dest_path = f'{self.gcs_bucket_prefix}/{project_uuid}/data/'
+        transfer_job = self.transfer_job_for_upload_area(source_bucket, upload_area_key, dest_path, export_job_id)
 
         try:
             maybe_existing_job = self.get_job(transfer_job.name)
@@ -105,16 +106,17 @@ class GcsXferStorage:
             else:
                 raise
 
-    def transfer_job_for_upload_area(self, source_bucket: str, upload_area_key: str, export_job_id: str) -> TransferJobSpec:
+    def transfer_job_for_upload_area(self, source_bucket: str, upload_area_key: str, dest_path: str, export_job_id: str) -> TransferJobSpec:
         return TransferJobSpec(name=f'transferJobs/{export_job_id}',
                                description=f'Transfer job for ingest upload-service area {upload_area_key} and export-job-id {export_job_id}',
                                project_id=self.project_id,
                                source_bucket=source_bucket,
-                               upload_area=upload_area_key,
-                               dest_bucket=self.gcs_dest_bucket,
+                               source_path=upload_area_key,
                                aws_access_key_id=self.aws_access_key_id,
                                aws_access_key_secret=self.aws_access_key_secret,
-                               gcs_notif_topic = self.gcs_notif_topic)
+                               dest_bucket=self.gcs_dest_bucket,
+                               dest_path=dest_path,
+                               gcs_notification_topic=self.gcs_notification_topic)
 
     def get_job(self, job_name: str) -> Optional[Dict]:
         two_seconds = 2

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -57,11 +57,11 @@ class TransferJobSpec:
                         'accessKeyId': self.aws_access_key_id,
                         'secretAccessKey': self.aws_access_key_secret
                     },
-                    'path': self.source_path + '/'
+                    'path': self.source_path
                 },
                 'gcsDataSink': {
                     'bucketName': self.dest_bucket,
-                    'path': self.dest_path + '/'
+                    'path': self.dest_path
                 },
                 'transferOptions': {
                     'overwriteObjectsAlreadyExistingInSink': False
@@ -90,8 +90,7 @@ class GcsXferStorage:
         self.logger.setLevel(logging.INFO)
 
     def transfer_upload_area(self, source_bucket: str, upload_area_key: str, project_uuid: str, export_job_id: str):
-        dest_path = f'{self.gcs_bucket_prefix}/{project_uuid}/data/'
-        transfer_job = self.transfer_job_for_upload_area(source_bucket, upload_area_key, dest_path, export_job_id)
+        transfer_job = self.transfer_job_for_upload_area(source_bucket, upload_area_key, project_uuid, export_job_id)
 
         try:
             maybe_existing_job = self.get_job(transfer_job.name)
@@ -106,16 +105,16 @@ class GcsXferStorage:
             else:
                 raise
 
-    def transfer_job_for_upload_area(self, source_bucket: str, upload_area_key: str, dest_path: str, export_job_id: str) -> TransferJobSpec:
+    def transfer_job_for_upload_area(self, source_bucket: str, upload_area_key: str, project_uuid: str, export_job_id: str) -> TransferJobSpec:
         return TransferJobSpec(name=f'transferJobs/{export_job_id}',
                                description=f'Transfer job for ingest upload-service area {upload_area_key} and export-job-id {export_job_id}',
                                project_id=self.project_id,
                                source_bucket=source_bucket,
-                               source_path=upload_area_key,
+                               source_path=f'{upload_area_key}/',
                                aws_access_key_id=self.aws_access_key_id,
                                aws_access_key_secret=self.aws_access_key_secret,
                                dest_bucket=self.gcs_dest_bucket,
-                               dest_path=dest_path,
+                               dest_path=f'{self.gcs_bucket_prefix}/{project_uuid}/data/',
                                gcs_notification_topic=self.gcs_notification_topic)
 
     def get_job(self, job_name: str) -> Optional[Dict]:

--- a/exporter/terra/terra_exporter.py
+++ b/exporter/terra/terra_exporter.py
@@ -3,7 +3,6 @@ from exporter.metadata import MetadataResource, MetadataService, DataFile
 from exporter.graph.graph_crawler import GraphCrawler
 from exporter.terra.dcp_staging_client import DcpStagingClient
 from typing import Iterable
-from multiprocessing import Process
 
 
 class TerraExporter:
@@ -18,27 +17,20 @@ class TerraExporter:
         self.dcp_staging_client = dcp_staging_client
 
     def export(self, process_uuid, submission_uuid, experiment_uuid, experiment_version, export_job_id):
-        meta_process = Process(target=self.export_metadata, args=(process_uuid, submission_uuid, experiment_uuid, experiment_version, export_job_id))
-        meta_process.start()
-        data_process = Process(target=self.export_data, args=(submission_uuid, export_job_id))
-        data_process.start()
-
-        meta_process.join()
-        data_process.join()
-
-
-    def export_metadata(self, process_uuid, submission_uuid, experiment_uuid, experiment_version, export_job_id):
         process = self.get_process(process_uuid)
         project = self.project_for_process(process)
-
+        submission = self.get_submission(submission_uuid)
+        
+        self.dcp_staging_client.transfer_data_files(submission, project.uuid, export_job_id)
+        
         experiment_graph = self.graph_crawler.generate_experiment_graph(process, project)
         
         self.dcp_staging_client.write_metadatas(experiment_graph.nodes.get_nodes(), project.uuid)
         self.dcp_staging_client.write_links(experiment_graph.links, experiment_uuid, experiment_version, project.uuid)
-        
-    def export_data(self, submission_uuid, export_job_id):
-        submission = self.get_submission(submission_uuid)
-        self.dcp_staging_client.transfer_data_files(submission, export_job_id)        
+
+    def export_data(self, submission_uuid, project_uuid, export_job_id):
+        submission = self.get_submission(submission_uuid)        
+        self.dcp_staging_client.transfer_data_files(submission, project_uuid, export_job_id)
 
     def export_update(self, metadata_urls: Iterable[str]):
         metadata_to_update = [self.metadata_service.fetch_resource(url) for url in metadata_urls]

--- a/exporter/terra/terra_listener.py
+++ b/exporter/terra/terra_listener.py
@@ -17,6 +17,12 @@ import json
 class ExperimentMessageParseExpection(Exception):
     pass
 
+class SubmissionMessageParseExpection(Exception):
+    pass
+
+class SimpleUpdateMessageParseExpection(Exception):
+    pass
+
 
 @dataclass
 class ExperimentMessage:
@@ -45,6 +51,18 @@ class ExperimentMessage:
 
 
 @dataclass
+class SubmissionMessage:
+    submission_uuid: str
+
+    @staticmethod
+    def from_dict(data: Dict) -> 'SubmissionMessage':
+        try:
+            return SubmissionMessage(data["documentUuid"])
+        except (KeyError, TypeError) as e:
+            raise SubmissionMessageParseExpection(e)
+
+
+@dataclass
 class SimpleUpdateMessage:
     metadata_urls: List[str]
     submission_uuid: str
@@ -59,7 +77,7 @@ class SimpleUpdateMessage:
                                        data["index"],
                                        data["total"])
         except (KeyError, TypeError) as e:
-            raise ExperimentMessageParseExpection(e)
+            raise SimpleUpdateMessageParseExpection(e)
 
 
 class _TerraListener(ConsumerProducerMixin):
@@ -69,6 +87,7 @@ class _TerraListener(ConsumerProducerMixin):
                  terra_exporter: TerraExporter,
                  job_service: TerraExportJobService,
                  experiment_queue_config: QueueConfig,
+                 data_queue_config: QueueConfig,
                  update_queue_config: QueueConfig,
                  publish_queue_config: QueueConfig,
                  executor: ThreadPoolExecutor):
@@ -76,6 +95,7 @@ class _TerraListener(ConsumerProducerMixin):
         self.terra_exporter = terra_exporter
         self.job_service = job_service
         self.experiment_queue_config = experiment_queue_config
+        self.data_queue_config = data_queue_config
         self.update_queue_config = update_queue_config
         self.publish_queue_config = publish_queue_config
         self.executor = executor
@@ -88,11 +108,15 @@ class _TerraListener(ConsumerProducerMixin):
                                         callbacks=[self.experiment_message_handler],
                                         prefetch_count=1)
 
+        data_consumer = _consumer([_TerraListener.queue_from_config(self.data_queue_config)],
+                                        callbacks=[self.data_message_handler],
+                                        prefetch_count=1)
+
         update_consumer = _consumer([_TerraListener.queue_from_config(self.update_queue_config)],
                                     callbacks=[self.update_message_handler],
                                     prefetch_count=1)
 
-        return [experiment_consumer, update_consumer]
+        return [experiment_consumer, data_consumer, update_consumer]
 
     def experiment_message_handler(self, body: str, msg: Message):
         return self.executor.submit(lambda: self._experiment_message_handler(body, msg))
@@ -114,6 +138,22 @@ class _TerraListener(ConsumerProducerMixin):
 
         except Exception as e:
             self.logger.error(f'Failed to export experiment message with body: {body}')
+            self.logger.exception(e)
+
+    def data_message_handler(self, body: str, msg: Message):
+        return self.executor.submit(lambda: self._data_message_handler(body, msg))
+
+    def _data_message_handler(self, body: str, msg: Message):
+        try:
+            sub = SubmissionMessage.from_dict(json.loads(body))
+            self.logger.info(f'Received data submission message for submission {sub.submission_uuid})')
+            self.terra_exporter.export_data(sub.submission_uuid)
+            self.logger.info(f'Data submission started --submission {sub.submission_uuid})')
+            
+            msg.ack()
+
+        except Exception as e:
+            self.logger.error(f'Failed to start data submission message with body: {body}')
             self.logger.exception(e)
 
     def update_message_handler(self, body: str, msg: Message):
@@ -145,16 +185,18 @@ class TerraListener:
                  terra_exporter: TerraExporter,
                  job_service: TerraExportJobService,
                  experiment_queue_config: QueueConfig,
+                 data_queue_config: QueueConfig,
                  update_queue_config: QueueConfig,
                  publish_queue_config: QueueConfig):
         self.amqp_conn_config = amqp_conn_config
         self.terra_exporter = terra_exporter
         self.job_service = job_service
         self.experiment_queue_config = experiment_queue_config
+        self.data_queue_config = data_queue_config
         self.update_queue_config = update_queue_config
         self.publish_queue_config = publish_queue_config
 
     def run(self):
         with Connection(self.amqp_conn_config.broker_url()) as conn:
-            _terra_listener = _TerraListener(conn, self.terra_exporter, self.job_service, self.experiment_queue_config, self.update_queue_config, self.publish_queue_config, ThreadPoolExecutor())
+            _terra_listener = _TerraListener(conn, self.terra_exporter, self.job_service, self.experiment_queue_config, self.data_queue_config, self.update_queue_config, self.publish_queue_config, ThreadPoolExecutor())
             _terra_listener.run()

--- a/exporter/terra/terra_listener.py
+++ b/exporter/terra/terra_listener.py
@@ -149,7 +149,7 @@ class _TerraListener(ConsumerProducerMixin):
         try:
             sub = DataExportMessage.from_dict(json.loads(body))
             self.logger.info(f'Received data submission message for submission {sub.submission_uuid})')
-            self.terra_exporter.export_data(sub.submission_uuid)
+            self.terra_exporter.export_data(sub.submission_uuid, sub.job_id)
             self.logger.info(f'Data submission started --submission {sub.submission_uuid})')
             
             msg.ack()

--- a/exporter/terra/terra_listener.py
+++ b/exporter/terra/terra_listener.py
@@ -53,12 +53,14 @@ class ExperimentMessage:
 @dataclass
 class DataExportMessage:
     submission_uuid: str
+    project_uuid: str
     job_id: str
 
     @staticmethod
     def from_dict(data: Dict) -> 'DataExportMessage':
         try:
-            return DataExportMessage(data["documentUuid"],
+            return DataExportMessage(data["submissionUuid"],
+                                     data["projectUuid"],
                                      data["exportJobId"])
         except (KeyError, TypeError) as e:
             raise DataExportMessageParseExpection(e)
@@ -110,15 +112,16 @@ class _TerraListener(ConsumerProducerMixin):
                                         callbacks=[self.experiment_message_handler],
                                         prefetch_count=1)
 
-        data_consumer = _consumer([_TerraListener.queue_from_config(self.data_queue_config)],
-                                        callbacks=[self.data_message_handler],
-                                        prefetch_count=1)
+        #data_consumer = _consumer([_TerraListener.queue_from_config(self.data_queue_config)],
+        #                                callbacks=[self.data_message_handler],
+        #                                prefetch_count=1)
 
         update_consumer = _consumer([_TerraListener.queue_from_config(self.update_queue_config)],
                                     callbacks=[self.update_message_handler],
                                     prefetch_count=1)
 
-        return [experiment_consumer, data_consumer, update_consumer]
+        #return [experiment_consumer, data_consumer, update_consumer]
+        return [experiment_consumer, update_consumer]
 
     def experiment_message_handler(self, body: str, msg: Message):
         return self.executor.submit(lambda: self._experiment_message_handler(body, msg))

--- a/exporter/terra/terra_listener.py
+++ b/exporter/terra/terra_listener.py
@@ -17,7 +17,7 @@ import json
 class ExperimentMessageParseExpection(Exception):
     pass
 
-class SubmissionMessageParseExpection(Exception):
+class DataExportMessageParseExpection(Exception):
     pass
 
 class SimpleUpdateMessageParseExpection(Exception):
@@ -51,15 +51,17 @@ class ExperimentMessage:
 
 
 @dataclass
-class SubmissionMessage:
+class DataExportMessage:
     submission_uuid: str
+    job_id: str
 
     @staticmethod
-    def from_dict(data: Dict) -> 'SubmissionMessage':
+    def from_dict(data: Dict) -> 'DataExportMessage':
         try:
-            return SubmissionMessage(data["documentUuid"])
+            return DataExportMessage(data["documentUuid"],
+                                     data["exportJobId"])
         except (KeyError, TypeError) as e:
-            raise SubmissionMessageParseExpection(e)
+            raise DataExportMessageParseExpection(e)
 
 
 @dataclass
@@ -145,7 +147,7 @@ class _TerraListener(ConsumerProducerMixin):
 
     def _data_message_handler(self, body: str, msg: Message):
         try:
-            sub = SubmissionMessage.from_dict(json.loads(body))
+            sub = DataExportMessage.from_dict(json.loads(body))
             self.logger.info(f'Received data submission message for submission {sub.submission_uuid})')
             self.terra_exporter.export_data(sub.submission_uuid)
             self.logger.info(f'Data submission started --submission {sub.submission_uuid})')


### PR DESCRIPTION
This PR contains the changes to propagate updates and additions to the terra staging area. 
Related user stories: 
[#77](https://app.zenhub.com/workspaces/dcp-ingest-product-development-5f71ca62a3cb47326bdc1b5c/issues/ebi-ait/dcp-ingest-central/77), [#78](https://app.zenhub.com/workspaces/dcp-ingest-product-development-5f71ca62a3cb47326bdc1b5c/issues/ebi-ait/dcp-ingest-central/78), [#153](https://app.zenhub.com/workspaces/dcp-ingest-product-development-5f71ca62a3cb47326bdc1b5c/issues/ebi-ait/dcp-ingest-central/153)
All the changes are self-contained in the exporter i.e. corresponding core changes aren't needed (at the moment). This PR doesn't contain changes related to:
- separating data and metadata listener
- removing blocking operation for job completion check/replacing with pub/sub notification (the latter is setup but notif doesn't seem to be coming through)