### PR TITLE
Fix timeout issue

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -84,6 +84,7 @@ def setup_terra_exporter() -> Thread:
     aws_access_key_id = os.environ['AWS_ACCESS_KEY_ID']
     aws_access_key_secret = os.environ['AWS_ACCESS_KEY_SECRET']
     gcs_svc_credentials_path = os.environ['GCP_SVC_ACCOUNT_KEY_PATH']
+    os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = gcs_svc_credentials_path
     gcp_project = os.environ['GCP_PROJECT']
     terra_bucket_name = os.environ['TERRA_BUCKET_NAME']
     terra_bucket_prefix = os.environ['TERRA_BUCKET_PREFIX']
@@ -99,7 +100,7 @@ def setup_terra_exporter() -> Thread:
                           .with_ingest_client(ingest_client)
                           .with_schema_service(schema_service)
                           .with_gcs_info(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix)
-                          .with_gcs_xfer(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix, aws_access_key_id, aws_access_key_secret, gcs_notification_topic)
+                          .with_gcs_xfer(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix, aws_access_key_id, aws_access_key_secret, gcs_notification_topic, gcs_notification_sub)
                           .build())
 
     terra_exporter = TerraExporter(ingest_client, metadata_service, graph_crawler, dcp_staging_client)

--- a/exporter/terra/dcp_staging_client.py
+++ b/exporter/terra/dcp_staging_client.py
@@ -13,6 +13,7 @@ from google.oauth2.service_account import Credentials
 import json
 
 from dataclasses import dataclass
+from functools import partial 
 
 
 @dataclass
@@ -63,7 +64,7 @@ class DcpStagingClient:
 
     def transfer_submission(self, submission: Dict, metadatas: Iterable[MetadataResource], project_uuid, export_job_id: str):
         self.transfer_data_files(submission, project_uuid, export_job_id)
-        callback = lambda: self.write_metadatas(metadatas, project_uuid, export_job_id)
+        callback = partial(self.write_metadatas, metadatas, project_uuid)
         self.gcs_xfer.subscribe_job_complete(export_job_id, callback)
 
     def transfer_data_files(self, submission: Dict, project_uuid, export_job_id: str):
@@ -72,6 +73,7 @@ class DcpStagingClient:
         self.gcs_xfer.transfer_upload_area(bucket_and_key[0], bucket_and_key[1], project_uuid, export_job_id)
 
     def write_metadatas(self, metadatas: Iterable[MetadataResource], project_uuid: str):
+        print(f"Writing metadata for project: {project_uuid}")
         for metadata in metadatas:
             self.write_metadata(metadata, project_uuid)
 

--- a/exporter/terra/dcp_staging_client.py
+++ b/exporter/terra/dcp_staging_client.py
@@ -69,7 +69,6 @@ class DcpStagingClient:
         self.gcs_xfer.subscribe_job_complete(export_job_id, callback)
 
     def write_metadatas(self, metadatas: Iterable[MetadataResource], project_uuid: str):
-        print(f"Writing metadata for project: {project_uuid}")
         for metadata in metadatas:
             self.write_metadata(metadata, project_uuid)
 
@@ -91,7 +90,6 @@ class DcpStagingClient:
             self.write_file_descriptor(metadata, project_uuid)
 
     def write_links(self, link_set: LinkSet, experiment_uuid: str, experiment_version: str, project_uuid: str):
-        print(f"Writing links for project: {project_uuid}")
         dest_object_key = f'{project_uuid}/links/{experiment_uuid}_{experiment_version}_{project_uuid}.json'
         links_json = self.generate_links_json(link_set)
         data_stream = DcpStagingClient.dict_to_json_stream(links_json)

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -171,8 +171,8 @@ class GcsXferStorage:
                 three_hours_in_seconds = 60 * 60 * 3
                 streaming_pull_future.result(timeout=three_hours_in_seconds)
             except TimeoutError:
-                raise Exception(f"Timed out waiting for data files to transfer for job {export_job_id}")
                 streaming_pull_future.cancel()
+                raise Exception(f"Timed out waiting for data files to transfer for job {export_job_id}")
 
     def _stop_pulling_messages(self, future):
         future.cancel()

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -140,12 +140,15 @@ class GcsXferStorage:
                 else:
                     raise
 
-    def subscribe_job_complete(self, job_name: str, callback):
+    def subscribe_job_complete(self, export_job_id: str, callback):
         subscription_path = self.gcs_subscriber.subscription_path(self.project_id, self.gcs_notification_sub)
 
         def cb(msg):
+            print(f"Received message {msg}")
             if msg.attributes:
-                if msg.attributes.transferJobName == job_name:
+                print(f"With job name {msg.attributes.transferJobName}")
+
+                if msg.attributes.eventType == "TRANSFER_OPERATION_SUCCESS" and msg.attributes.transferJobName == f"transferJobs/{export_job_id}":
                     callback()
             msg.ack()
         

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -66,11 +66,11 @@ class TransferJobSpec:
                 'transferOptions': {
                     'overwriteObjectsAlreadyExistingInSink': False
                 }
-            }#,
-            #'notificationConfig': {
-            #    'pubsubTopic': self.gcs_notification_topic,
-            #    'payloadFormat': 'JSON'
-            #}
+            },
+            'notificationConfig': {
+                'pubsubTopic': self.gcs_notification_topic,
+                'payloadFormat': 'JSON'
+            }
         }
 
 

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -106,7 +106,6 @@ class GcsXferStorage:
             raise
 
     def transfer_job_for_upload_area(self, source_bucket: str, upload_area_key: str, project_uuid: str, export_job_id: str) -> TransferJobSpec:
-        print(f"Starting transfer job with name transferJobs/{export_job_id}")
         return TransferJobSpec(name=f'transferJobs/{export_job_id}',
                                description=f'Transfer job for ingest upload-service area {upload_area_key} and export-job-id {export_job_id}',
                                project_id=self.project_id,

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -144,11 +144,10 @@ class GcsXferStorage:
         subscription_path = self.gcs_subscriber.subscription_path(self.project_id, self.gcs_notification_sub)
 
         def cb(msg):
-            print(f"Received message {msg}")
             if msg.attributes:
-                print(f"With job name {msg.attributes.transferJobName}")
+                print(f"Job with job name {msg.attributes['transferJobName']} complete")
 
-                if msg.attributes.eventType == "TRANSFER_OPERATION_SUCCESS" and msg.attributes.transferJobName == f"transferJobs/{export_job_id}":
+                if msg.attributes["eventType"] == "TRANSFER_OPERATION_SUCCESS" and msg.attributes["transferJobName"] == f"transferJobs/{export_job_id}":
                     callback()
             msg.ack()
         

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -69,6 +69,7 @@ class TransferJobSpec:
             },
             'notificationConfig': {
                 'pubsubTopic': self.gcs_notification_topic,
+                'eventTypes': ['TRANSFER_OPERATION_SUCCESS'],
                 'payloadFormat': 'JSON'
             }
         }

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -145,10 +145,11 @@ class GcsXferStorage:
 
         def cb(msg):
             if msg.attributes:
-                print(f"Job with job name {msg.attributes['transferJobName']} complete")
-
                 if msg.attributes["eventType"] == "TRANSFER_OPERATION_SUCCESS" and msg.attributes["transferJobName"] == f"transferJobs/{export_job_id}":
+                    print(f"Export job with job name {msg.attributes['transferJobName']} complete")
                     callback()
+                else:
+                    print(f"Export job with job name {msg.attributes['transferJobName']} incomplete with event type {msg.attributes['eventType']}")
             msg.ack()
         
         streaming_pull_future = self.gcs_subscriber.subscribe(subscription_path, callback=cb)

--- a/exporter/terra/terra_exporter.py
+++ b/exporter/terra/terra_exporter.py
@@ -16,21 +16,14 @@ class TerraExporter:
         self.graph_crawler = graph_crawler
         self.dcp_staging_client = dcp_staging_client
 
-    def export(self, process_uuid, submission_uuid, experiment_uuid, experiment_version, export_job_id):
+    def export(self, process_uuid, submission_uuid, experiment_uuid, experiment_version, export_job_id):      
         process = self.get_process(process_uuid)
         project = self.project_for_process(process)
         submission = self.get_submission(submission_uuid)
-        
-        self.dcp_staging_client.transfer_data_files(submission, project.uuid, export_job_id)
-        
         experiment_graph = self.graph_crawler.generate_experiment_graph(process, project)
-        
-        self.dcp_staging_client.write_metadatas(experiment_graph.nodes.get_nodes(), project.uuid)
-        self.dcp_staging_client.write_links(experiment_graph.links, experiment_uuid, experiment_version, project.uuid)
+        metadatas = experiment_graph.nodes.get_nodes()
 
-    def export_data(self, submission_uuid, project_uuid, export_job_id):
-        submission = self.get_submission(submission_uuid)        
-        self.dcp_staging_client.transfer_data_files(submission, project_uuid, export_job_id)
+        self.dcp_staging_client.transfer_submission(submission, metadatas, project.uuid, export_job_id)
 
     def export_update(self, metadata_urls: Iterable[str]):
         metadata_to_update = [self.metadata_service.fetch_resource(url) for url in metadata_urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ google-cloud-storage
 boto3
 boto3-stubs[s3]
 cachetools
--e git+https://github.com/HumanCellAtlas/ingest-client.git@74472037#egg=hca_ingest
+-e git+https://github.com/ebi-ait/ingest-client.git@782dd754#egg=hca_ingest
 smart_open[all]
 google-api-python-client


### PR DESCRIPTION
Fixes [#191](https://app.zenhub.com/workspaces/dcp-ingest-product-development-5f71ca62a3cb47326bdc1b5c/issues/ebi-ait/dcp-ingest-central/191)

Exporter now uses [Pub/Sub for transfer](https://cloud.google.com/storage-transfer/docs/pub-sub-transfer) to track progress of transferring data files.

This is not the ideal way to do this but I have implemented with minimal changes. I think a better approach would be to have a long running process that pulls from the Pub/Sub queue in a different thread. A queue should then be used to add metadata export jobs which will be picked up whenever the corresponding data files are transferred. Currently, the pulling process is spun up once per export job and terminated when the export is completed.

This kind of logic should also eventually be implemented for metadata transfers. We are still periodically polling for job completion with a timeout there.