### PR TITLE
Fix rate limit error ebi-ait/dcp-ingest-central#289

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -26,22 +26,17 @@ DISABLE_MANIFEST = os.environ.get('DISABLE_MANIFEST', False)
 DEFAULT_RABBIT_URL = os.path.expandvars(
     os.environ.get('RABBIT_URL', 'amqp://localhost:5672'))
 
-EXCHANGE = 'ingest.bundle.exchange'
+EXCHANGE = 'ingest.exporter.exchange'
 EXCHANGE_TYPE = 'topic'
 
 ASSAY_QUEUE_MANIFEST = 'ingest.manifests.assays.new'
 EXPERIMENT_QUEUE_TERRA = 'ingest.terra.experiments.new'
 
-UPDATE_QUEUE_TERRA = 'ingest.terra.updates.new'
+ASSAY_ROUTING_KEY = 'ingest.exporter.manifest.submitted'
+EXPERIMENT_ROUTING_KEY = 'ingest.exporter.experiment.submitted'
 
-ASSAY_ROUTING_KEY = 'ingest.assay.manifest.submitted'
-EXPERIMENT_ROUTING_KEY = 'ingest.assay.experiment.submitted'
-
-UPDATE_ROUTING_KEY = 'ingest.update.experiment.submitted'
-ANALYSIS_ROUTING_KEY = 'ingest.bundle.analysis.submitted'
-
-ASSAY_COMPLETED_ROUTING_KEY = 'ingest.assay.manifest.completed'
-EXPERIMENT_COMPLETED_ROUTING_KEY = 'ingest.assay.experiment.exported'
+ASSAY_COMPLETED_ROUTING_KEY = 'ingest.exporter.manifest.completed'
+EXPERIMENT_COMPLETED_ROUTING_KEY = 'ingest.exporter.experiment.exported'
 
 
 RETRY_POLICY = {
@@ -107,10 +102,9 @@ def setup_terra_exporter() -> Thread:
     rabbit_port = int(os.environ.get('RABBIT_PORT', '5672'))
     amqp_conn_config = AmqpConnConfig(rabbit_host, rabbit_port)
     experiment_queue_config = QueueConfig(EXPERIMENT_QUEUE_TERRA, EXPERIMENT_ROUTING_KEY, EXCHANGE, EXCHANGE_TYPE, False, None)
-    update_queue_config = QueueConfig(UPDATE_QUEUE_TERRA, UPDATE_ROUTING_KEY, EXCHANGE, EXCHANGE_TYPE, False, None)
     publish_queue_config = QueueConfig(None, EXPERIMENT_COMPLETED_ROUTING_KEY, EXCHANGE, EXCHANGE_TYPE, True, RETRY_POLICY)
 
-    terra_listener = TerraListener(amqp_conn_config, terra_exporter, terra_job_service, experiment_queue_config, update_queue_config, publish_queue_config)
+    terra_listener = TerraListener(amqp_conn_config, terra_exporter, terra_job_service, experiment_queue_config, publish_queue_config)
 
     terra_exporter_listener_process = Thread(target=lambda: terra_listener.run())
     terra_exporter_listener_process.start()

--- a/exporter.py
+++ b/exporter.py
@@ -95,8 +95,8 @@ def setup_terra_exporter() -> Thread:
                           .with_gcs_xfer(gcs_svc_credentials_path, gcp_project, terra_bucket_name, terra_bucket_prefix, aws_access_key_id, aws_access_key_secret)
                           .build())
 
-    terra_exporter = TerraExporter(ingest_client, metadata_service, graph_crawler, dcp_staging_client)
     terra_job_service = TerraExportJobService(ingest_client)
+    terra_exporter = TerraExporter(ingest_client, metadata_service, graph_crawler, dcp_staging_client, terra_job_service)
 
     rabbit_host = os.environ.get('RABBIT_HOST', 'localhost')
     rabbit_port = int(os.environ.get('RABBIT_PORT', '5672'))

--- a/exporter/terra/dcp_staging_client.py
+++ b/exporter/terra/dcp_staging_client.py
@@ -4,7 +4,7 @@ from exporter.metadata import MetadataResource, DataFile, FileChecksums
 from exporter.graph.experiment_graph import LinkSet
 from exporter.schema import SchemaService
 from exporter.terra.gcs import GcsXferStorage, GcsStorage, Streamable, TransferJobSpec
-from typing import Iterable, Dict, Tuple
+from typing import Iterable, Dict, Tuple, Callable
 
 from io import StringIO
 
@@ -67,8 +67,8 @@ class DcpStagingClient:
         transfer_job_spec, success = self.gcs_xfer.transfer_upload_area(bucket_and_key[0], bucket_and_key[1], project_uuid, export_job_id)
         return transfer_job_spec, success
 
-    def wait_for_transfer_to_complete(self, job_name: str):
-        self.gcs_xfer.assert_job_complete(job_name)
+    def wait_for_transfer_to_complete(self, job_name: str, compute_wait_time_sec:Callable, start_wait_time_sec: int, max_wait_time_sec: int):
+        self.gcs_xfer.wait_for_job_to_complete(job_name, compute_wait_time_sec, start_wait_time_sec, max_wait_time_sec)
 
     def write_metadatas(self, metadatas: Iterable[MetadataResource], project_uuid: str):
         for metadata in metadatas:

--- a/exporter/terra/dcp_staging_client.py
+++ b/exporter/terra/dcp_staging_client.py
@@ -3,7 +3,7 @@ from exporter import utils
 from exporter.metadata import MetadataResource, DataFile, FileChecksums
 from exporter.graph.experiment_graph import LinkSet
 from exporter.schema import SchemaService
-from exporter.terra.gcs import GcsXferStorage, GcsStorage, Streamable
+from exporter.terra.gcs import GcsXferStorage, GcsStorage, Streamable, TransferJobSpec
 from typing import Iterable, Dict, Tuple
 
 from io import StringIO
@@ -61,10 +61,14 @@ class DcpStagingClient:
         self.schema_service = schema_service
         self.ingest_client = ingest_client
 
-    def transfer_data_files(self, submission: Dict, project_uuid, export_job_id: str):
+    def transfer_data_files(self, submission: Dict, project_uuid, export_job_id: str) -> (TransferJobSpec, bool):
         upload_area = submission["stagingDetails"]["stagingAreaLocation"]["value"]
         bucket_and_key = self.bucket_and_key_for_upload_area(upload_area)
-        self.gcs_xfer.transfer_upload_area(bucket_and_key[0], bucket_and_key[1], project_uuid, export_job_id)
+        transfer_job_spec, success = self.gcs_xfer.transfer_upload_area(bucket_and_key[0], bucket_and_key[1], project_uuid, export_job_id)
+        return transfer_job_spec, success
+
+    def wait_for_transfer_to_complete(self, job_name: str):
+        self.gcs_xfer.assert_job_complete(job_name)
 
     def write_metadatas(self, metadatas: Iterable[MetadataResource], project_uuid: str):
         for metadata in metadatas:

--- a/exporter/terra/dcp_staging_client.py
+++ b/exporter/terra/dcp_staging_client.py
@@ -87,8 +87,8 @@ class DcpStagingClient:
         if metadata.metadata_type == "file":
             self.write_file_descriptor(metadata, project_uuid)
 
-    def write_links(self, link_set: LinkSet, experiment_uuid: str, experiment_version: str, project_uuid: str):
-        dest_object_key = f'{project_uuid}/links/{experiment_uuid}_{experiment_version}_{project_uuid}.json'
+    def write_links(self, link_set: LinkSet, process_uuid: str, process_version: str, project_uuid: str):
+        dest_object_key = f'{project_uuid}/links/{process_uuid}_{process_version}_{project_uuid}.json'
         links_json = self.generate_links_json(link_set)
         data_stream = DcpStagingClient.dict_to_json_stream(links_json)
         self.write_to_staging_bucket(dest_object_key, data_stream)

--- a/exporter/terra/gcs.py
+++ b/exporter/terra/gcs.py
@@ -1,7 +1,5 @@
-from sys import implementation
 import googleapiclient.discovery
 from typing import IO, Dict, Any, Union, Optional
-from exporter.metadata import DataFile
 from datetime import datetime
 import time
 
@@ -83,23 +81,26 @@ class GcsXferStorage:
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.INFO)
 
-    def transfer_upload_area(self, source_bucket: str, upload_area_key: str, project_uuid: str, export_job_id: str):
-        transfer_job = self.transfer_job_for_upload_area(source_bucket, upload_area_key, project_uuid, export_job_id)
-
+    def transfer_upload_area(self, source_bucket: str, upload_area_key: str, project_uuid: str, export_job_id: str)-> (TransferJobSpec, bool):
+        transfer_job_spec = self.transfer_job_spec_for_upload_area(source_bucket, upload_area_key, project_uuid, export_job_id)
+        success = False
         try:
-            maybe_existing_job = self.get_job(transfer_job.name)
-            if maybe_existing_job is not None:
-                self.assert_job_complete(transfer_job.name)
-            else:
-                self.client.transferJobs().create(body=transfer_job.to_dict()).execute()
-                self.assert_job_complete(transfer_job.name)
+            maybe_existing_job = self.get_job(transfer_job_spec.name)
+
+            if maybe_existing_job is None:
+                self.client.transferJobs().create(body=transfer_job_spec.to_dict()).execute()
+                success = True
+
         except HttpError as e:
             if e.resp.status == 409:
-                self.assert_job_complete(transfer_job.name)
+                success = False
+                return transfer_job_spec, success
             else:
                 raise
 
-    def transfer_job_for_upload_area(self, source_bucket: str, upload_area_key: str, project_uuid: str, export_job_id: str) -> TransferJobSpec:
+        return transfer_job_spec, success
+
+    def transfer_job_spec_for_upload_area(self, source_bucket: str, upload_area_key: str, project_uuid: str, export_job_id: str) -> TransferJobSpec:
         return TransferJobSpec(name=f'transferJobs/{export_job_id}',
                                description=f'Transfer job for ingest upload-service area {upload_area_key} and export-job-id {export_job_id}',
                                project_id=self.project_id,

--- a/exporter/terra/terra_exporter.py
+++ b/exporter/terra/terra_exporter.py
@@ -33,8 +33,9 @@ class TerraExporter:
 
         self.logger.info(f"The export data flag has been set to {export_data}")
 
-        if export_data:
+        if export_data and not self.job_service.is_data_transfer_complete(export_job_id):
             self.logger.info("Exporting data files..")
+
             transfer_job_spec, success = self.dcp_staging_client.transfer_data_files(submission, project.uuid, export_job_id)
 
             if success:

--- a/exporter/terra/terra_exporter.py
+++ b/exporter/terra/terra_exporter.py
@@ -32,25 +32,37 @@ class TerraExporter:
         export_data = "Export metadata" not in submission.get("submitActions", [])
 
         self.logger.info(f"The export data flag has been set to {export_data}")
-
         if export_data and not self.job_service.is_data_transfer_complete(export_job_id):
             self.logger.info("Exporting data files..")
-
             transfer_job_spec, success = self.dcp_staging_client.transfer_data_files(submission, project.uuid, export_job_id)
-
-            if success:
-                # Only the exporter process which is successful should be polling GCP Transfer service if the job is complete
-                # This is to avoid hitting the rate limit 500 requests per 100 sec https://cloud.google.com/storage-transfer/quotas
-                self.dcp_staging_client.wait_for_transfer_to_complete(transfer_job_spec.name)
-                self.job_service.set_data_transfer_complete(export_job_id)
-            else:
-                self.job_service.wait_for_data_transfer_to_complete(export_job_id)
+            self._wait_for_data_transfer_to_complete(export_job_id, success, transfer_job_spec)
 
         self.logger.info("Exporting metadata..")
         experiment_graph = self.graph_crawler.generate_complete_experiment_graph(process, project)
         
         self.dcp_staging_client.write_metadatas(experiment_graph.nodes.get_nodes(), project.uuid)
         self.dcp_staging_client.write_links(experiment_graph.links, process_uuid, process.dcp_version, project.uuid)
+
+    # Only the exporter process which is successful should be polling GCP Transfer service if the job is complete
+    # This is to avoid hitting the rate limit 500 requests per 100 sec https://cloud.google.com/storage-transfer/quotas
+    def _wait_for_data_transfer_to_complete(self, export_job_id, success, transfer_job_spec):
+        def compute_wait_time(start_wait_time_sec):
+            max_wait_interval_sec = 10 * 60
+            return min(start_wait_time_sec * 2, max_wait_interval_sec)
+
+        max_wait_time_sec = 60 * 60 * 6
+        start_wait_time_sec = 2
+        if success:
+            self.logger.info("Google Cloud Transfer job was successfully created..")
+            self.logger.info("Waiting for job to complete..")
+            self.dcp_staging_client.wait_for_transfer_to_complete(transfer_job_spec.name, compute_wait_time,
+                                                                  start_wait_time_sec, max_wait_time_sec)
+            self.job_service.set_data_transfer_complete(export_job_id)
+        else:
+            self.logger.info("Google Cloud Transfer job was already created..")
+            self.logger.info("Waiting for job to complete..")
+            self.job_service.wait_for_data_transfer_to_complete(export_job_id, compute_wait_time, start_wait_time_sec,
+                                                                max_wait_time_sec)
 
     def get_process(self, process_uuid) -> MetadataResource:
         return MetadataResource.from_dict(self.ingest_client.get_entity_by_uuid('processes', process_uuid))

--- a/exporter/terra/terra_exporter.py
+++ b/exporter/terra/terra_exporter.py
@@ -21,7 +21,7 @@ class TerraExporter:
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.INFO)
 
-    def export(self, process_uuid, submission_uuid, experiment_uuid, experiment_version, export_job_id):
+    def export(self, process_uuid, submission_uuid, export_job_id):
         process = self.get_process(process_uuid)
         project = self.project_for_process(process)
         submission = self.get_submission(submission_uuid)
@@ -38,11 +38,7 @@ class TerraExporter:
         experiment_graph = self.graph_crawler.generate_complete_experiment_graph(process, project)
         
         self.dcp_staging_client.write_metadatas(experiment_graph.nodes.get_nodes(), project.uuid)
-        self.dcp_staging_client.write_links(experiment_graph.links, experiment_uuid, experiment_version, project.uuid)
-
-    def export_update(self, metadata_urls: Iterable[str]):
-        metadata_to_update = [self.metadata_service.fetch_resource(url) for url in metadata_urls]
-        self.dcp_staging_client.write_metadatas(metadata_to_update)
+        self.dcp_staging_client.write_links(experiment_graph.links, process_uuid, process.dcp_version, project.uuid)
 
     def get_process(self, process_uuid) -> MetadataResource:
         return MetadataResource.from_dict(self.ingest_client.get_entity_by_uuid('processes', process_uuid))

--- a/exporter/terra/terra_exporter.py
+++ b/exporter/terra/terra_exporter.py
@@ -2,9 +2,10 @@ from ingest.api.ingestapi import IngestApi
 from exporter.metadata import MetadataResource, MetadataService, DataFile
 from exporter.graph.graph_crawler import GraphCrawler
 from exporter.terra.dcp_staging_client import DcpStagingClient
-from typing import Iterable
 
 import logging
+
+from exporter.terra.terra_export_job import TerraExportJobService
 
 
 class TerraExporter:
@@ -12,11 +13,13 @@ class TerraExporter:
                  ingest_client: IngestApi,
                  metadata_service: MetadataService,
                  graph_crawler: GraphCrawler,
-                 dcp_staging_client: DcpStagingClient):
+                 dcp_staging_client: DcpStagingClient,
+                 job_service: TerraExportJobService):
         self.ingest_client = ingest_client
         self.metadata_service = metadata_service
         self.graph_crawler = graph_crawler
         self.dcp_staging_client = dcp_staging_client
+        self.job_service = job_service
 
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.INFO)
@@ -32,7 +35,15 @@ class TerraExporter:
 
         if export_data:
             self.logger.info("Exporting data files..")
-            self.dcp_staging_client.transfer_data_files(submission, project.uuid, export_job_id)
+            transfer_job_spec, success = self.dcp_staging_client.transfer_data_files(submission, project.uuid, export_job_id)
+
+            if success:
+                # Only the exporter process which is successful should be polling GCP Transfer service if the job is complete
+                # This is to avoid hitting the rate limit 500 requests per 100 sec https://cloud.google.com/storage-transfer/quotas
+                self.dcp_staging_client.wait_for_transfer_to_complete(transfer_job_spec.name)
+                self.job_service.set_data_transfer_complete(export_job_id)
+            else:
+                self.job_service.wait_for_data_transfer_to_complete(export_job_id)
 
         self.logger.info("Exporting metadata..")
         experiment_graph = self.graph_crawler.generate_complete_experiment_graph(process, project)

--- a/exporter/terra/terra_listener.py
+++ b/exporter/terra/terra_listener.py
@@ -89,7 +89,7 @@ class _TerraListener(ConsumerProducerMixin):
             self.logger.exception(e)
 
     def log_complete_assay(self, job_id: str, assay_process_id: str):
-        self.job_service.complete_assay(job_id, assay_process_id)
+        self.job_service.create_export_entity(job_id, assay_process_id)
 
     @staticmethod
     def queue_from_config(queue_config: QueueConfig) -> Queue:

--- a/exporter/terra/terra_listener.py
+++ b/exporter/terra/terra_listener.py
@@ -17,17 +17,12 @@ import json
 class ExperimentMessageParseExpection(Exception):
     pass
 
-class SimpleUpdateMessageParseExpection(Exception):
-    pass
-
 
 @dataclass
 class ExperimentMessage:
     process_id: str
     process_uuid: str
     submission_uuid: str
-    experiment_uuid: str
-    experiment_version: str
     experiment_index: int
     total: int
     job_id: str
@@ -38,31 +33,11 @@ class ExperimentMessage:
             return ExperimentMessage(data["documentId"],
                                      data["documentUuid"],
                                      data["envelopeUuid"],
-                                     data["bundleUuid"],
-                                     data["versionTimestamp"],
                                      data["index"],
                                      data["total"],
                                      data["exportJobId"])
         except (KeyError, TypeError) as e:
             raise ExperimentMessageParseExpection(e)
-
-
-@dataclass
-class SimpleUpdateMessage:
-    metadata_urls: List[str]
-    submission_uuid: str
-    index: int
-    total: int
-
-    @staticmethod
-    def from_dict(data: Dict) -> 'SimpleUpdateMessage':
-        try:
-            return SimpleUpdateMessage(data["callbackLinks"],
-                                       data["envelopeUuid"],
-                                       data["index"],
-                                       data["total"])
-        except (KeyError, TypeError) as e:
-            raise SimpleUpdateMessageParseExpection(e)
 
 
 class _TerraListener(ConsumerProducerMixin):
@@ -72,14 +47,12 @@ class _TerraListener(ConsumerProducerMixin):
                  terra_exporter: TerraExporter,
                  job_service: TerraExportJobService,
                  experiment_queue_config: QueueConfig,
-                 update_queue_config: QueueConfig,
                  publish_queue_config: QueueConfig,
                  executor: ThreadPoolExecutor):
         self.connection = connection
         self.terra_exporter = terra_exporter
         self.job_service = job_service
         self.experiment_queue_config = experiment_queue_config
-        self.update_queue_config = update_queue_config
         self.publish_queue_config = publish_queue_config
         self.executor = executor
 
@@ -91,11 +64,7 @@ class _TerraListener(ConsumerProducerMixin):
                                         callbacks=[self.experiment_message_handler],
                                         prefetch_count=1)
 
-        update_consumer = _consumer([_TerraListener.queue_from_config(self.update_queue_config)],
-                                    callbacks=[self.update_message_handler],
-                                    prefetch_count=1)
-
-        return [experiment_consumer, update_consumer]
+        return [experiment_consumer]
 
     def experiment_message_handler(self, body: str, msg: Message):
         return self.executor.submit(lambda: self._experiment_message_handler(body, msg))
@@ -104,7 +73,7 @@ class _TerraListener(ConsumerProducerMixin):
         try:
             exp = ExperimentMessage.from_dict(json.loads(body))
             self.logger.info(f'Received experiment message for process {exp.process_uuid} (index {exp.experiment_index} for submission {exp.submission_uuid})')
-            self.terra_exporter.export(exp.process_uuid, exp.submission_uuid, exp.experiment_uuid, exp.experiment_version, exp.job_id)
+            self.terra_exporter.export(exp.process_uuid, exp.submission_uuid, exp.job_id)
             self.logger.info(f'Exported experiment for process uuid {exp.process_uuid} (--index {exp.experiment_index} --total {exp.total} --submission {exp.submission_uuid})')
             self.log_complete_assay(exp.job_id, exp.process_id)
 
@@ -118,19 +87,6 @@ class _TerraListener(ConsumerProducerMixin):
         except Exception as e:
             self.logger.error(f'Failed to export experiment message with body: {body}')
             self.logger.exception(e)
-
-    def update_message_handler(self, body: str, msg: Message):
-        return self.executor.submit(lambda: self._update_message_handler(body, msg))
-
-    def _update_message_handler(self, body: str, msg: Message):
-        update_message = SimpleUpdateMessage.from_dict(json.loads(body))
-        self.logger.info(f'Received metadata update message for submission {update_message.submission_uuid}) '
-                         f'(--index {update_message.index} --total {update_message.total})')
-        self.terra_exporter.export_update(update_message.metadata_urls)
-        self.logger.info(f'Exported updates for metadata URLs: [ {",".join(update_message.metadata_urls)} ] '
-                         f'(--index {update_message.index} --total {update_message.total})')
-
-        msg.ack()
 
     def log_complete_assay(self, job_id: str, assay_process_id: str):
         self.job_service.complete_assay(job_id, assay_process_id)
@@ -148,16 +104,14 @@ class TerraListener:
                  terra_exporter: TerraExporter,
                  job_service: TerraExportJobService,
                  experiment_queue_config: QueueConfig,
-                 update_queue_config: QueueConfig,
                  publish_queue_config: QueueConfig):
         self.amqp_conn_config = amqp_conn_config
         self.terra_exporter = terra_exporter
         self.job_service = job_service
         self.experiment_queue_config = experiment_queue_config
-        self.update_queue_config = update_queue_config
         self.publish_queue_config = publish_queue_config
 
     def run(self):
         with Connection(self.amqp_conn_config.broker_url()) as conn:
-            _terra_listener = _TerraListener(conn, self.terra_exporter, self.job_service, self.experiment_queue_config, self.update_queue_config, self.publish_queue_config, ThreadPoolExecutor())
+            _terra_listener = _TerraListener(conn, self.terra_exporter, self.job_service, self.experiment_queue_config, self.publish_queue_config, ThreadPoolExecutor())
             _terra_listener.run()

--- a/receiver.py
+++ b/receiver.py
@@ -1,4 +1,6 @@
 from kombu.mixins import ConsumerProducerMixin
+from kombu import Consumer
+from typing import Type
 
 
 class Worker(ConsumerProducerMixin):
@@ -6,8 +8,8 @@ class Worker(ConsumerProducerMixin):
         self.connection = connection
         self.queues = queues
 
-    def get_consumers(self, Consumer, channel):
-        return [Consumer(queues=self.queues,
+    def get_consumers(self, consumer: Type[Consumer], channel):
+        return [consumer(queues=self.queues,
                          callbacks=[self.on_message])]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ cachetools
 -e git+https://github.com/ebi-ait/ingest-client.git@7f04ab9a#egg=hca_ingest
 smart_open[all]
 google-api-python-client
+polling


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#289

Main logic change :

Only the exporter process which is successful to create the data transfer job should be polling GCP to check if the job is complete. Other processes will check the isDataTransferComplete flag in the export job context info from Ingest Core.
This is to avoid hitting the GCP rate limit 500 requests per 100 sec https://cloud.google.com/storage-transfer/quotas

I tested with a submission using the dataset which has 897 assay processes where this issue has occured. The error is not consistently being replicated before the change but I've done several runs and the error hasn't happened again yet so far. In theory, this should greatly reduce the requests we're sending to GCP.