### PR TITLE
Create staging_area.json file

### DIFF
--- a/exporter/terra/dcp_staging_client.py
+++ b/exporter/terra/dcp_staging_client.py
@@ -180,3 +180,8 @@ class DcpStagingClient:
                 raise Exception("ingest_client must be set")
             else:
                 return DcpStagingClient(self.gcs_storage, self.gcs_xfer, self.schema_service, self.ingest_client)
+
+    def write_staging_area_json(self, project_uuid: str):
+        dest_object_key = f'{project_uuid}/staging_area.json'
+        data_stream = DcpStagingClient.dict_to_json_stream({'is_delta': False})
+        self.write_to_staging_bucket(dest_object_key, data_stream)

--- a/exporter/terra/terra_exporter.py
+++ b/exporter/terra/terra_exporter.py
@@ -46,6 +46,7 @@ class TerraExporter:
         
         self.dcp_staging_client.write_metadatas(experiment_graph.nodes.get_nodes(), project.uuid)
         self.dcp_staging_client.write_links(experiment_graph.links, process_uuid, process.dcp_version, project.uuid)
+        self.dcp_staging_client.write_staging_area_json(project.uuid)
 
     # Only the exporter process which is successful should be polling GCP Transfer service if the job is complete
     # This is to avoid hitting the rate limit 500 requests per 100 sec https://cloud.google.com/storage-transfer/quotas


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#514

Tested in dev:

```
$ gsutil ls  gs://broad-dsp-monster-hca-dev-ebi-staging/dev/d9e704e4-4fdd-4c76-9220-c327895586f6
gs://broad-dsp-monster-hca-dev-ebi-staging/dev/d9e704e4-4fdd-4c76-9220-c327895586f6/staging_area.json
gs://broad-dsp-monster-hca-dev-ebi-staging/dev/d9e704e4-4fdd-4c76-9220-c327895586f6/descriptors/
gs://broad-dsp-monster-hca-dev-ebi-staging/dev/d9e704e4-4fdd-4c76-9220-c327895586f6/links/
gs://broad-dsp-monster-hca-dev-ebi-staging/dev/d9e704e4-4fdd-4c76-9220-c327895586f6/metadata/

$ gsutil cat gs://broad-dsp-monster-hca-dev-ebi-staging/dev/d9e704e4-4fdd-4c76-9220-c327895586f6/staging_area.json | jq
{
  "is_delta": false
}
```