### PR TITLE
dcp-845 Fix Spreadsheet Exporter Cache Issue

### DIFF
--- a/exporter/terra/experiment/config.py
+++ b/exporter/terra/experiment/config.py
@@ -17,6 +17,7 @@ from exporter.terra.experiment.handler import TerraExperimentHandler
 from exporter.terra.gcs.config import GcpConfig
 from exporter.terra.gcs.storage import GcsStorage
 
+LOGGER_NAME = "TerraExperimentExporter"
 RETRY_POLICY = {
     'interval_start': 0,
     'interval_step': 2,
@@ -55,13 +56,13 @@ def setup_terra_experiment_exporter() -> Thread:
     graph_crawler = GraphCrawler(metadata_service)
 
     gcp_config = GcpConfig.from_env()
-    gcs_storage = GcsStorage(gcp_config.gcp_project, gcp_config.gcp_credentials_path)
+    gcs_storage = GcsStorage(gcp_config.gcp_project, gcp_config.gcp_credentials_path, LOGGER_NAME)
     terra_config = TerraConfig.from_env()
-    terra_client = TerraStorageClient(gcs_storage, schema_service, terra_config.terra_bucket_name, terra_config.terra_bucket_prefix)
+    terra_client = TerraStorageClient(gcs_storage, schema_service, terra_config.terra_bucket_name, terra_config.terra_bucket_prefix, LOGGER_NAME)
     ingest_service = IngestService(ingest_client)
-    terra_exporter = TerraExperimentExporter(ingest_service, graph_crawler, terra_client)
+    terra_exporter = TerraExperimentExporter(ingest_service, graph_crawler, terra_client, LOGGER_NAME)
 
-    handler = TerraExperimentHandler(terra_exporter, ingest_service, EXPERIMENT_COMPLETE_CONFIG)
+    handler = TerraExperimentHandler(terra_exporter, ingest_service, EXPERIMENT_COMPLETE_CONFIG, LOGGER_NAME)
     listener = QueueListener(EXPERIMENT_QUEUE_CONFIG, handler)
     connector = QueueConnector(amqp_conn_config, listener)
 

--- a/exporter/terra/experiment/exporter.py
+++ b/exporter/terra/experiment/exporter.py
@@ -1,11 +1,8 @@
 import logging
 
-from exporter import utils
 from exporter.graph.crawler import GraphCrawler
 from exporter.ingest.service import IngestService
 from exporter.terra.storage import TerraStorageClient
-
-LOGGER_NAME = 'TerraExperimentExporter'
 
 
 class TerraExperimentExporter:
@@ -13,20 +10,19 @@ class TerraExperimentExporter:
             self,
             ingest_service: IngestService,
             graph_crawler: GraphCrawler,
-            terra_client: TerraStorageClient
+            terra_client: TerraStorageClient,
+            logger_name: str = __name__
     ):
         self.graph_crawler = graph_crawler
         self.terra_client = terra_client
         self.ingest_service = ingest_service
-        self.logger = logging.getLogger(LOGGER_NAME)
+        self.logger = logging.getLogger(logger_name)
 
-    @utils.exec_time(logging.getLogger(LOGGER_NAME), logging.INFO)
     def export(self, process_uuid):
-        self.logger.info(f"export started")
         process = self.ingest_service.get_metadata('processes', process_uuid)
         project = self.ingest_service.project_for_process(process)
 
-        self.logger.info("Exporting metadata")
+        self.logger.info("Exporting Experiment metadata")
         experiment_graph = self.graph_crawler.generate_complete_experiment_graph(process, project)
 
         self.terra_client.write_metadatas(experiment_graph.nodes.get_nodes(), project.uuid)

--- a/exporter/terra/experiment/message.py
+++ b/exporter/terra/experiment/message.py
@@ -24,17 +24,3 @@ class ExperimentMessage:
                                      data["exportJobId"])
         except (KeyError, TypeError) as e:
             raise ExperimentMessageParseException(e)
-
-    @staticmethod
-    def as_dict(exp: 'ExperimentMessage') -> Dict:
-        try:
-            return {
-                "documentId": exp.process_id,
-                "documentUuid": exp.process_uuid,
-                "envelopeUuid": exp.submission_uuid,
-                "index": exp.experiment_index,
-                "total": exp.total,
-                "exportJobId": exp.job_id
-            }
-        except (KeyError, TypeError) as e:
-            raise ExperimentMessageParseException(e)

--- a/exporter/terra/gcs/storage.py
+++ b/exporter/terra/gcs/storage.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from io import BufferedReader, StringIO
 from time import sleep
 from typing import Union, IO, Any
@@ -8,20 +9,18 @@ from google.api_core.retry import Retry, if_exception_type
 from google.cloud.storage import Client, Blob, Bucket
 from google.oauth2.service_account import Credentials
 
-from exporter.session_context import SessionContext
 from exporter.terra.exceptions import UploadPollingException
 
 Streamable = Union[BufferedReader, StringIO, IO[Any]]
 
 
 class GcsStorage:
-    def __init__(self, project_id: str, credentials_path: str):
+    def __init__(self, project_id: str, credentials_path: str, logger_name: str = __name__):
         with open(credentials_path) as source:
             info = json.load(source)
         credentials: Credentials = Credentials.from_service_account_info(info)
         self.client = Client(project=project_id, credentials=credentials)
-
-        self.logger = SessionContext.register_logger(__name__)
+        self.logger = logging.getLogger(logger_name)
 
     def write(self, bucket_name: str, key: str, data_stream: Streamable):
         bucket: Bucket = self.client.bucket(bucket_name)

--- a/exporter/terra/spreadsheet/config.py
+++ b/exporter/terra/spreadsheet/config.py
@@ -15,6 +15,7 @@ from exporter.terra.gcs.storage import GcsStorage
 
 from .handler import SpreadsheetHandler
 
+LOGGER_NAME = 'TerraSpreadsheetExporter'
 EXCHANGE = 'ingest.exporter.exchange'
 SPREADSHEET_QUEUE_CONFIG = QueueConfig(
     EXCHANGE,
@@ -38,11 +39,11 @@ def setup_terra_spreadsheet_exporter() -> Thread:
     schema_service = SchemaService(ingest_client)
 
     gcp_config = GcpConfig.from_env()
-    gcs_storage = GcsStorage(gcp_config.gcp_project, gcp_config.gcp_credentials_path)
+    gcs_storage = GcsStorage(gcp_config.gcp_project, gcp_config.gcp_credentials_path, LOGGER_NAME)
     terra_config = TerraConfig.from_env()
-    terra_client = TerraStorageClient(gcs_storage, schema_service, terra_config.terra_bucket_name, terra_config.terra_bucket_prefix)
+    terra_client = TerraStorageClient(gcs_storage, schema_service, terra_config.terra_bucket_name, terra_config.terra_bucket_prefix, LOGGER_NAME)
 
-    handler = SpreadsheetHandler(ingest_service, terra_client)
+    handler = SpreadsheetHandler(ingest_service, terra_client, LOGGER_NAME)
     listener = QueueListener(SPREADSHEET_QUEUE_CONFIG, handler)
     connector = QueueConnector(amqp_conn_config, listener)
 

--- a/exporter/terra/spreadsheet/exporter.py
+++ b/exporter/terra/spreadsheet/exporter.py
@@ -20,7 +20,7 @@ class SpreadsheetExporter:
         self.downloader = WorkbookDownloader(self.ingest.api)
         self.logger = logging.getLogger('IngestSpreadsheetExporter')
 
-    def export_spreadsheet(self, job_id: str, project_uuid: str, submission_uuid: str):
+    def export_spreadsheet(self, project_uuid: str, submission_uuid: str):
         self.logger.info("Generating Spreadsheet")
         workbook = self.downloader.get_workbook_from_submission(submission_uuid)
         self.logger.info("Generating Spreadsheet Metadata")

--- a/exporter/terra/spreadsheet/exporter.py
+++ b/exporter/terra/spreadsheet/exporter.py
@@ -1,6 +1,5 @@
 import hashlib
 import logging
-import os
 import uuid
 from tempfile import NamedTemporaryFile as TempFile
 
@@ -55,10 +54,9 @@ class SpreadsheetExporter:
     def create_supplementary_file_metadata(self, spreadsheet_file: TempFile, project_meta: Metadata) -> Metadata:
         schema_url = self.ingest.api.get_latest_schema_url('type', 'file', 'supplementary_file')
         filename = f'metadata_{project_meta.uuid}.xlsx'
-        spreadsheet_file.seek(0, os.SEEK_END)
-        spreadsheet_size = spreadsheet_file.tell()
         spreadsheet_file.seek(0)
         spreadsheet_bytes = spreadsheet_file.read()
+        spreadsheet_size = len(spreadsheet_bytes)
         s256 = hashlib.sha256(spreadsheet_bytes)
         s1 = hashlib.sha1(spreadsheet_bytes)
         crc = f'{crc32c.crc32c(spreadsheet_bytes):08x}'

--- a/exporter/terra/spreadsheet/exporter.py
+++ b/exporter/terra/spreadsheet/exporter.py
@@ -2,21 +2,20 @@ import hashlib
 import logging
 import os
 import uuid
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile as TempFile
 
-import crc32c as crc32c
+import crc32c
 from hca_ingest.downloader.workbook import WorkbookDownloader
 
 from exporter.graph.info.supplementary_files import SupplementaryFilesInfo
 from exporter.graph.experiment import ExperimentGraph
 from exporter.ingest.service import IngestService
-from exporter.metadata.resource import MetadataResource
-from exporter.terra.exceptions import SpreadsheetExportError
+from exporter.metadata.resource import MetadataResource as Metadata
 from exporter.terra.storage import TerraStorageClient
 
 
 class SpreadsheetExporter:
-    def __init__(self, ingest_service: IngestService, terra_client:  TerraStorageClient):
+    def __init__(self, ingest_service: IngestService, terra_client: TerraStorageClient):
         self.ingest = ingest_service
         self.terra = terra_client
         self.downloader = WorkbookDownloader(self.ingest.api)
@@ -26,54 +25,51 @@ class SpreadsheetExporter:
         self.logger.info("Generating Spreadsheet")
         workbook = self.downloader.get_workbook_from_submission(submission_uuid)
         self.logger.info("Generating Spreadsheet Metadata")
-        project = self.ingest.get_metadata(entity_type='projects', uuid=project_uuid)
-        with NamedTemporaryFile() as spreadsheet_file:
+        project_meta = self.ingest.get_metadata(entity_type='projects', uuid=project_uuid)
+        with TempFile() as spreadsheet_file:
             workbook.save(spreadsheet_file.name)
             # todo: make it available in broker as well.
-            file = self.create_supplementary_file_metadata(spreadsheet_file, project)
+            file_meta = self.create_supplementary_file_metadata(spreadsheet_file, project_meta)
             self.logger.info("Writing to Terra")
-            self.write_to_terra(spreadsheet_file, project, file)
+            self.write_to_terra(spreadsheet_file, project_meta, file_meta)
 
-    def write_to_terra(self, spreadsheet_file: NamedTemporaryFile,
-                       project: MetadataResource,
-                       file: MetadataResource):
-        self.terra.write_metadata(file, project.uuid)
-        self.write_links(file, project)
+    def write_to_terra(self, spreadsheet_file: TempFile, project_meta: Metadata, file_meta: Metadata):
+        self.terra.write_metadata(file_meta, project_meta.uuid)
+        self.write_links(file_meta, project_meta)
         spreadsheet_file.seek(0)
         self.terra.write_to_staging_bucket(
-            object_key=f'{project.uuid}/data/{file.full_resource["fileName"]}',
+            object_key=f'{project_meta.uuid}/data/{file_meta.full_resource["fileName"]}',
             data_stream=spreadsheet_file
         )
 
-    def write_links(self, file: MetadataResource, project: MetadataResource):
-        supplementary_files_info = SupplementaryFilesInfo(for_entity=project, files=[file])
-        experiment_graph = ExperimentGraph.from_supplementary_files_info(supplementary_files_info, project)
+    def write_links(self, file_meta: Metadata, project_meta: Metadata):
+        info = SupplementaryFilesInfo(for_entity=project_meta, files=[file_meta])
+        experiment_graph = ExperimentGraph.from_supplementary_files_info(info, project_meta)
         self.terra.write_links(
             experiment_graph.links,
-            file.uuid,
-            file.dcp_version,
-            project.uuid
+            file_meta.uuid,
+            file_meta.dcp_version,
+            project_meta.uuid
         )
 
-    def create_supplementary_file_metadata(self, spreadsheet: NamedTemporaryFile,
-                                           project: MetadataResource) -> MetadataResource:
+    def create_supplementary_file_metadata(self, spreadsheet_file: TempFile, project_meta: Metadata) -> Metadata:
         schema_url = self.ingest.api.get_latest_schema_url('type', 'file', 'supplementary_file')
-        filename = f'metadata_{project.uuid}.xlsx'
-        spreadsheet.seek(0, os.SEEK_END)
-        size_in_bytes = spreadsheet.tell()
-        spreadsheet.seek(0)
-        spreadsheet_bytes = spreadsheet.read()
+        filename = f'metadata_{project_meta.uuid}.xlsx'
+        spreadsheet_file.seek(0, os.SEEK_END)
+        spreadsheet_size = spreadsheet_file.tell()
+        spreadsheet_file.seek(0)
+        spreadsheet_bytes = spreadsheet_file.read()
         s256 = hashlib.sha256(spreadsheet_bytes)
         s1 = hashlib.sha1(spreadsheet_bytes)
         crc = f'{crc32c.crc32c(spreadsheet_bytes):08x}'
         metadata_uuid = str(uuid.uuid5(uuid.NAMESPACE_DNS, f'{filename}_metadata'))
         datafile_uuid = str(uuid.uuid5(uuid.NAMESPACE_DNS, f'{filename}_data'))
-        return MetadataResource.from_dict({
+        return Metadata.from_dict({
             "fileName": filename,
             "dataFileUuid": datafile_uuid,
             "cloudUrl": None,
             "fileContentType": "xlsx",
-            "size": size_in_bytes,
+            "size": spreadsheet_size,
             "checksums": {
                 "sha256": s256.hexdigest(),
                 "crc32c": crc,
@@ -81,10 +77,10 @@ class SpreadsheetExporter:
                 "s3_etag": 'n/a - not in s3'
             },
             "uuid": {"uuid": metadata_uuid},
-            "dcpVersion": project.dcp_version,
+            "dcpVersion": project_meta.dcp_version,
             "type": "file",
-            "submissionDate": project.full_resource['submissionDate'],
-            "updateDate": project.full_resource['updateDate'],
+            "submissionDate": project_meta.full_resource['submissionDate'],
+            "updateDate": project_meta.full_resource['updateDate'],
             "content": {
                 "describedBy": schema_url,
                 "schema_type": "file",

--- a/exporter/terra/spreadsheet/exporter.py
+++ b/exporter/terra/spreadsheet/exporter.py
@@ -14,11 +14,11 @@ from exporter.terra.storage import TerraStorageClient
 
 
 class SpreadsheetExporter:
-    def __init__(self, ingest_service: IngestService, terra_client: TerraStorageClient):
+    def __init__(self, ingest_service: IngestService, terra_client: TerraStorageClient, logger_name: str = __name__):
         self.ingest = ingest_service
         self.terra = terra_client
         self.downloader = WorkbookDownloader(self.ingest.api)
-        self.logger = logging.getLogger('IngestSpreadsheetExporter')
+        self.logger = logging.getLogger(logger_name)
 
     def export_spreadsheet(self, project_uuid: str, submission_uuid: str):
         self.logger.info("Generating Spreadsheet")

--- a/exporter/terra/spreadsheet/handler.py
+++ b/exporter/terra/spreadsheet/handler.py
@@ -30,7 +30,7 @@ class SpreadsheetHandler(MessageHandler):
         message = SpreadsheetExporterMessage(body)
         self.logger.info('Received spreadsheet export message, informing ingest')
         self.ingest.set_spreadsheet_generation(message.job_id, ExportContextState.STARTED)
-        self.exporter.export_spreadsheet(message.job_id, message.project_uuid, message.submission_uuid)
+        self.exporter.export_spreadsheet(message.project_uuid, message.submission_uuid)
         self.logger.info('Spreadsheet export finished, informing ingest')
         self.ingest.set_spreadsheet_generation(message.job_id, ExportContextState.COMPLETE)
         self.logger.info('Acknowledging spreadsheet export message')

--- a/exporter/terra/spreadsheet/handler.py
+++ b/exporter/terra/spreadsheet/handler.py
@@ -11,10 +11,10 @@ from .message import SpreadsheetExporterMessage
 
 
 class SpreadsheetHandler(MessageHandler):
-    def __init__(self, ingest_service: IngestService, terra_client:  TerraStorageClient):
-        super().__init__('IngestSpreadsheetExporter')
+    def __init__(self, ingest_service: IngestService, terra_client:  TerraStorageClient, logger_name: str = __name__):
+        super().__init__(logger_name)
         self.ingest = ingest_service
-        self.exporter = SpreadsheetExporter(ingest_service, terra_client)
+        self.exporter = SpreadsheetExporter(ingest_service, terra_client, logger_name)
 
     def set_context(self, body: dict) -> SessionContext:
         return SessionContext(

--- a/exporter/terra/submission/config.py
+++ b/exporter/terra/submission/config.py
@@ -15,6 +15,8 @@ from .exporter import TerraSubmissionExporter
 from .handler import TerraSubmissionHandler
 from .responder import TerraTransferResponder
 
+
+LOGGER_NAME = 'TerraSubmissionExporter'
 EXCHANGE = 'ingest.exporter.exchange'
 SUBMISSION_QUEUE_CONFIG = QueueConfig(
     EXCHANGE,
@@ -37,9 +39,9 @@ def setup_terra_submissions_exporter() -> Tuple[Thread, Thread]:
     ingest_client = IngestApi(ingest_api_url)
     ingest_service = IngestService(ingest_client)
     terra_client = TerraTransferClient.from_env()
-    terra_exporter = TerraSubmissionExporter(ingest_service, terra_client)
+    terra_exporter = TerraSubmissionExporter(ingest_service, terra_client, LOGGER_NAME)
 
-    handler = TerraSubmissionHandler(terra_exporter, ingest_service)
+    handler = TerraSubmissionHandler(terra_exporter, ingest_service, LOGGER_NAME)
     listener = QueueListener(SUBMISSION_QUEUE_CONFIG, handler)
     connector = QueueConnector(amqp_conn_config, listener)
 

--- a/exporter/terra/submission/exporter.py
+++ b/exporter/terra/submission/exporter.py
@@ -7,10 +7,10 @@ from exporter.terra.transfer import TerraTransferClient
 
 
 class TerraSubmissionExporter:
-    def __init__(self, ingest_service: IngestService, terra_client: TerraTransferClient):
+    def __init__(self, ingest_service: IngestService, terra_client: TerraTransferClient, logger_name: str = __name__):
         self.ingest_service = ingest_service
         self.terra_client = terra_client
-        self.logger = logging.getLogger('TerraSubmissionExporter')
+        self.logger = logging.getLogger(logger_name)
 
     def start_data_file_transfer(self, job_id: str, submission_uuid: str, project_uuid: str):
         self.logger.info(f"Getting Submission for data transfer")

--- a/exporter/terra/submission/handler.py
+++ b/exporter/terra/submission/handler.py
@@ -10,8 +10,8 @@ from .message import SubmissionExportMessage
 
 
 class TerraSubmissionHandler(MessageHandler):
-    def __init__(self, submission_exporter: TerraSubmissionExporter, ingest_service: IngestService):
-        super().__init__('TerraSubmissionExporter')
+    def __init__(self, submission_exporter: TerraSubmissionExporter, ingest_service: IngestService, logger_name: str = __name__):
+        super().__init__(logger_name)
         self.submission_exporter = submission_exporter
         self.ingest_service = ingest_service
 

--- a/exporter/terra/submission/responder.py
+++ b/exporter/terra/submission/responder.py
@@ -16,7 +16,7 @@ class TerraTransferResponder:
         self.ingest = ingest_service
         self.subscription_path = SubscriberClient.subscription_path(gcp_config.gcp_project, gcp_config.gcp_topic)
         topic_path = SubscriberClient.topic_path(gcp_config.gcp_project, gcp_config.gcp_topic)
-        self.logger = SessionContext.register_logger(__name__)
+        self.logger = SessionContext.register_logger("TerraTransferResponder")
 
         with open(gcp_config.gcp_credentials_path) as source:
             credentials_file = json.load(source)

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-hca-ingest~=2.5.2
+hca-ingest
 requests
 kombu
 jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ grpcio-status==1.48.1
     # via
     #   google-api-core
     #   google-cloud-pubsub
-hca-ingest==2.5.2
+hca-ingest==2.6.0
     # via -r requirements.in
 httplib2==0.20.4
     # via

--- a/tests/exporter/terra/spreadsheet/test_exporter.py
+++ b/tests/exporter/terra/spreadsheet/test_exporter.py
@@ -90,8 +90,7 @@ def test_happy_path(exporter: SpreadsheetExporter,
     # uses an exporter fixture
 
     # when
-    exporter.export_spreadsheet(job_id='test_job_id',
-                                project_uuid=project['uuid']['uuid'],
+    exporter.export_spreadsheet(project_uuid=project['uuid']['uuid'],
                                 submission_uuid=submission['uuid']['uuid'])
 
     # then
@@ -108,8 +107,7 @@ def test_exception_during_export(failing_exporter: SpreadsheetExporter,
     # when
     with pytest.raises(RuntimeError):
         project_uuid = 'test-project-uuid'
-        failing_exporter.export_spreadsheet(job_id='test_job_id',
-                                            project_uuid=project_uuid,
+        failing_exporter.export_spreadsheet(project_uuid=project_uuid,
                                             submission_uuid='test-submission-uuid')
 
 


### PR DESCRIPTION
GitHub: ebi-ait/dcp-ingest-central#845
ZenHub: dcp-845
 
- [x] Fix Spreadsheet Exporter Cache Issue (new ingest Client)
- [x] Only read the spreadsheet file once before sending to terra
- [x] Naming fix-ups
- [x] Exporter Param fix-up
- [x] logging with same session_context across all components of export