### PR TITLE
dcp-873 Spreadsheet Filenames and UUIDs

### DIFF
--- a/exporter/terra/spreadsheet/exporter.py
+++ b/exporter/terra/spreadsheet/exporter.py
@@ -55,9 +55,7 @@ class SpreadsheetExporter:
 
     def create_supplementary_file_metadata(self, spreadsheet_file: TempFile, project_meta: Metadata, submission_uuid: str) -> Metadata:
         schema_url = self.ingest.api.get_latest_schema_url('type', 'file', 'supplementary_file')
-        short_name = project_meta.metadata_json.get('project_core', {}).get('project_short_name')
-        if not short_name:
-            short_name = project_meta.uuid
+        short_name = project_meta.metadata_json.get('project_core', {}).get('project_short_name', project_meta.uuid)
         date_suffix = parse_date_string(project_meta.dcp_version).strftime('%d-%m-%Y')
         filename = f'{short_name}_metadata_{date_suffix}.xlsx'
         spreadsheet_file.seek(0)

--- a/exporter/terra/spreadsheet/exporter.py
+++ b/exporter/terra/spreadsheet/exporter.py
@@ -5,6 +5,7 @@ from tempfile import NamedTemporaryFile as TempFile
 
 import crc32c
 from hca_ingest.downloader.workbook import WorkbookDownloader
+from hca_ingest.utils.date import parse_date_string
 
 from exporter.graph.info.supplementary_files import SupplementaryFilesInfo
 from exporter.graph.experiment import ExperimentGraph
@@ -23,12 +24,13 @@ class SpreadsheetExporter:
     def export_spreadsheet(self, project_uuid: str, submission_uuid: str):
         self.logger.info("Generating Spreadsheet")
         workbook = self.downloader.get_workbook_from_submission(submission_uuid)
+
         self.logger.info("Generating Spreadsheet Metadata")
         project_meta = self.ingest.get_metadata(entity_type='projects', uuid=project_uuid)
         with TempFile() as spreadsheet_file:
             workbook.save(spreadsheet_file.name)
             # todo: make it available in broker as well.
-            file_meta = self.create_supplementary_file_metadata(spreadsheet_file, project_meta)
+            file_meta = self.create_supplementary_file_metadata(spreadsheet_file, project_meta, submission_uuid)
             self.logger.info("Writing to Terra")
             self.write_to_terra(spreadsheet_file, project_meta, file_meta)
 
@@ -51,17 +53,21 @@ class SpreadsheetExporter:
             project_meta.uuid
         )
 
-    def create_supplementary_file_metadata(self, spreadsheet_file: TempFile, project_meta: Metadata) -> Metadata:
+    def create_supplementary_file_metadata(self, spreadsheet_file: TempFile, project_meta: Metadata, submission_uuid: str) -> Metadata:
         schema_url = self.ingest.api.get_latest_schema_url('type', 'file', 'supplementary_file')
-        filename = f'metadata_{project_meta.uuid}.xlsx'
+        short_name = project_meta.metadata_json.get('project_core', {}).get('project_short_name')
+        if not short_name:
+            short_name = project_meta.uuid
+        date_suffix = parse_date_string(project_meta.dcp_version).strftime('%d-%m-%Y')
+        filename = f'{short_name}_metadata_{date_suffix}.xlsx'
         spreadsheet_file.seek(0)
         spreadsheet_bytes = spreadsheet_file.read()
         spreadsheet_size = len(spreadsheet_bytes)
         s256 = hashlib.sha256(spreadsheet_bytes)
         s1 = hashlib.sha1(spreadsheet_bytes)
         crc = f'{crc32c.crc32c(spreadsheet_bytes):08x}'
-        metadata_uuid = str(uuid.uuid5(uuid.NAMESPACE_DNS, f'{filename}_metadata'))
-        datafile_uuid = str(uuid.uuid5(uuid.NAMESPACE_DNS, f'{filename}_data'))
+        metadata_uuid = str(uuid.uuid5(uuid.NAMESPACE_DNS, f'{submission_uuid}_metadata'))
+        datafile_uuid = str(uuid.uuid5(uuid.NAMESPACE_DNS, f'{submission_uuid}_data'))
         return Metadata.from_dict({
             "fileName": filename,
             "dataFileUuid": datafile_uuid,

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ grpcio-status==1.48.1
     # via
     #   google-api-core
     #   google-cloud-pubsub
-hca-ingest==2.6.0
+hca-ingest==2.7.1
     # via -r requirements.in
 httplib2==0.20.4
     # via
@@ -121,6 +121,8 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.21
     # via cffi
+pyjwt==2.6.0
+    # via hca-ingest
 pyparsing==3.0.9
     # via
     #   httplib2

--- a/tests/exporter/terra/spreadsheet/test_exporter.py
+++ b/tests/exporter/terra/spreadsheet/test_exporter.py
@@ -1,3 +1,6 @@
+import uuid
+from collections import namedtuple
+from datetime import datetime
 from tempfile import NamedTemporaryFile
 from unittest.mock import Mock, ANY
 
@@ -13,46 +16,90 @@ from exporter.schema.resource import SchemaResource
 from exporter.terra.spreadsheet.exporter import SpreadsheetExporter
 from exporter.terra.storage import TerraStorageClient
 
+MetadataFile = namedtuple('MetadataFile', ['uuid', 'filename_prefix', 'filename_suffix', 'data_uuid'])
+
 
 @pytest.fixture
-def ingest_service(mocker, ingest_api):
+def ingest_service(ingest_api):
     ingest_service: IngestService = IngestService(ingest_api)
     return ingest_service
 
 
 @pytest.fixture
-def ingest_api(mocker, submission, project):
+def ingest_api(mocker, submission_dict, project_dict):
     ingest_api: IngestApi = mocker.Mock(spec=IngestApi)
-    ingest_api.get_submission_by_uuid.return_value = submission
+    ingest_api.get_submission_by_uuid.return_value = submission_dict
     ingest_api.get_latest_schema_url.return_value = 'https://schema.humancellatlas.org/type/file/2.5.0/supplementary_file'
-    ingest_api.get_entity_by_uuid.return_value = project
+    ingest_api.get_entity_by_uuid.return_value = project_dict
     return ingest_api
 
 
 @pytest.fixture
-def project():
-    return {
-        "uuid": {"uuid": "project-uuid"},
-        "dcpVersion": "2022-05-29T13:51:08.593000Z",
-        "content": {
-            "describedBy": "https://schema.humancellatlas.org/type/project/17.0.0/project",
-        },
-        "type": "file",
-        "submissionDate": "2022-03-28T13:51:08.593000Z",
-        "updateDate": "2022-05-28T13:51:08.593000Z",
-    }
+def submission_uuid():
+    return str(uuid.uuid4())
 
 
 @pytest.fixture
-def submission():
+def new_submission_uuid():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def submission_dict(submission_uuid):
     return {
-        "uuid": {"uuid": 'submission-uuid'},
+        "uuid": {"uuid": submission_uuid},
         "_links": {
             "self": {
                 "href": "http://ingest/submissionEnvelopes/submission-id"
             }
         }
     }
+
+
+@pytest.fixture
+def project_uuid():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture(params=[{}, {"project_short_name": "Test_Project"}], ids=["project without short name", "project with short name"])
+def project_dict(project_uuid, request):
+    return {
+        "uuid": {"uuid": project_uuid},
+        "dcpVersion": "2022-05-29T13:51:08.593000Z",
+        "content": {
+            "describedBy": "https://schema.humancellatlas.org/type/project/17.0.0/project",
+            "project_core": request.param
+        },
+        "type": "project",
+        "submissionDate": "2022-03-28T13:51:08.593000Z",
+        "updateDate": "2022-05-28T13:51:08.593000Z",
+    }
+
+
+@pytest.fixture
+def project(project_dict) -> MetadataResource:
+    return MetadataResource.from_dict(project_dict)
+
+
+@pytest.fixture
+def updated_project(project_dict) -> MetadataResource:
+    project_dict['dcpVersion'] = datetime.utcnow().isoformat() + 'Z'
+    return MetadataResource.from_dict(project_dict)
+
+
+@pytest.fixture
+def supplementary_file(exporter, project, submission_uuid, terra_client):
+    return create_supplementary_file(exporter, project, submission_uuid, terra_client)
+
+
+@pytest.fixture
+def updated_supplementary_file(exporter, updated_project, submission_uuid, terra_client):
+    return create_supplementary_file(exporter, updated_project, submission_uuid, terra_client)
+
+
+@pytest.fixture
+def new_supplementary_file(exporter, updated_project, new_submission_uuid, terra_client):
+    return create_supplementary_file(exporter, updated_project, new_submission_uuid, terra_client)
 
 
 @pytest.fixture
@@ -76,7 +123,9 @@ def exporter(ingest_service, terra_client, workbook, mocker):
 @pytest.fixture()
 def failing_exporter(ingest_service, terra_client, mocker):
     exporter = SpreadsheetExporter(ingest_service, terra_client)
-    exporter.downloader.get_workbook_from_submission = mocker.Mock(side_effect=RuntimeError('spreadsheet generation problem'))
+    exporter.downloader.get_workbook_from_submission = mocker.Mock(
+        side_effect=RuntimeError('spreadsheet generation problem')
+    )
     return exporter
 
 
@@ -84,14 +133,14 @@ def test_happy_path(exporter: SpreadsheetExporter,
                     ingest_service: Mock,
                     terra_client: Mock,
                     project,
-                    submission,
+                    submission_uuid,
                     caplog):
     # given
     # uses an exporter fixture
 
     # when
-    exporter.export_spreadsheet(project_uuid=project['uuid']['uuid'],
-                                submission_uuid=submission['uuid']['uuid'])
+    exporter.export_spreadsheet(project_uuid=project.uuid,
+                                submission_uuid=submission_uuid)
 
     # then
     actual_file_metadata = check_file_metadata(project, terra_client)
@@ -100,28 +149,53 @@ def test_happy_path(exporter: SpreadsheetExporter,
     assert "Generating Spreadsheet" in caplog.text
 
 
-def test_exception_during_export(failing_exporter: SpreadsheetExporter,
-                                 caplog):
+def test_exception_during_export(failing_exporter: SpreadsheetExporter, project_uuid, submission_uuid, caplog):
     # given an exception is thrown while generating the spreadsheet
 
     # when
     with pytest.raises(RuntimeError):
-        project_uuid = 'test-project-uuid'
         failing_exporter.export_spreadsheet(project_uuid=project_uuid,
-                                            submission_uuid='test-submission-uuid')
+                                            submission_uuid=submission_uuid)
 
 
-def test_spreadsheet_metadata_entity(exporter, project, submission, workbook, terra_client):
+def create_supplementary_file(exporter, project, submission_uuid, terra_client):
     with NamedTemporaryFile() as spreadsheet_file:
-        workbook.save(spreadsheet_file.name)
-        project_metadata = MetadataResource.from_dict(project)
-        file_metadata = exporter.create_supplementary_file_metadata(spreadsheet_file, project_metadata, submission['uuid']['uuid'])
-        check_file_metadata(project_metadata=project_metadata, file_metadata=file_metadata, terra_client=terra_client)
+        file = exporter.create_supplementary_file_metadata(spreadsheet_file,
+                                                           project,
+                                                           submission_uuid)
+        check_file_metadata(project, terra_client, file)
+        return file
 
 
-def check_spreadsheet_copied_to_terra(actual_file_metadata, project, terra_client):
+def test_spreadsheet_metadata_entity(supplementary_file):
+    pass
+
+
+def test_filenames_differ_with_changed_dcp_version(supplementary_file, updated_supplementary_file):
+    initial = get_file_info(supplementary_file)
+    updated = get_file_info(updated_supplementary_file)
+
+    assert_that(initial.uuid).is_equal_to(updated.uuid)
+    assert_that(initial.data_uuid).is_equal_to(updated.data_uuid)
+    assert_that(initial.filename_prefix).is_equal_to(updated.filename_prefix)
+
+    assert_that(initial.filename_suffix).is_not_equal_to(updated.filename_suffix)
+
+
+def test_metadata_uuids_differ_with_new_submission(supplementary_file, new_supplementary_file):
+    initial = get_file_info(supplementary_file)
+    new = get_file_info(new_supplementary_file)
+
+    assert_that(initial.uuid).is_not_equal_to(new.uuid)
+    assert_that(initial.data_uuid).is_not_equal_to(new.data_uuid)
+
+    assert_that(initial.filename_prefix).is_equal_to(new.filename_prefix)
+
+
+def check_spreadsheet_copied_to_terra(actual_file_metadata: MetadataResource,
+                                      project: MetadataResource, terra_client):
     terra_client.write_to_staging_bucket.assert_called_with(
-        object_key=f'{project["uuid"]["uuid"]}/data/{actual_file_metadata.full_resource["fileName"]}',
+        object_key=f'{project.uuid}/data/{actual_file_metadata.full_resource["fileName"]}',
         data_stream=ANY
     )
 
@@ -137,9 +211,7 @@ def check_generated_links(actual_file_metadata: MetadataResource,
                                                 project_metadata.uuid)
 
 
-def check_file_metadata(project_metadata: MetadataResource | dict, terra_client=None, file_metadata=None):
-    if isinstance(project_metadata, dict):
-        project_metadata = MetadataResource.from_dict(project_metadata)
+def check_file_metadata(project_metadata: MetadataResource, terra_client=None, file_metadata=None):
     if terra_client and not file_metadata:
         terra_client.write_metadata.assert_called_with(ANY, project_metadata.uuid)
         if file_metadata:
@@ -148,15 +220,26 @@ def check_file_metadata(project_metadata: MetadataResource | dict, terra_client=
     assert_that(file_metadata.metadata_json['file_core']) \
         .has_format('xlsx') \
         .has_file_source("DCP/2 Ingest") \
-        .has_content_description([
-        {
+        .has_content_description([{
             "text": "metadata spreadsheet",
             "ontology": "data:2193",
             "ontology_label": "Database entry metadata"
-        }
-    ])
+        }])
+    filename = file_metadata.full_resource['fileName']
+    short_name = project_metadata.metadata_json.get('project_core', {}).get('project_short_name')
+    assert_that(filename) \
+        .starts_with(short_name if short_name else project_metadata.uuid) \
+        .contains('_metadata_') \
+        .contains(datetime.fromisoformat(file_metadata.dcp_version.removesuffix('Z')).strftime('%d-%m-%Y')) \
+        .ends_with('.xlsx')
     TerraStorageClient.validate_json_doc(file_metadata.get_content())
-    TerraStorageClient.update_schema_info_and_validate(FileDescriptor.from_file_metadata(file_metadata).to_dict(),
-                                                       SchemaResource(schema_url='https://schema.humancellatlas.org/system/2.0.0/file_descriptor',
-                                                                      schema_version='2.0.0'))
+    TerraStorageClient.update_schema_info_and_validate(
+        FileDescriptor.from_file_metadata(file_metadata).to_dict(),
+        SchemaResource(schema_url='https://schema.humancellatlas.org/system/2.0.0/file_descriptor', schema_version='2.0.0'))
     return file_metadata
+
+
+def get_file_info(file: MetadataResource) -> MetadataFile:
+    filename = file.full_resource['fileName']
+    name_split = filename.split('_metadata_')
+    return MetadataFile(file.uuid, name_split[0],  name_split[1], file.full_resource['dataFileUuid'])

--- a/tests/exporter/terra/spreadsheet/test_exporter.py
+++ b/tests/exporter/terra/spreadsheet/test_exporter.py
@@ -111,11 +111,11 @@ def test_exception_during_export(failing_exporter: SpreadsheetExporter,
                                             submission_uuid='test-submission-uuid')
 
 
-def test_spreadsheet_metadata_entity(exporter, project, workbook, terra_client):
+def test_spreadsheet_metadata_entity(exporter, project, submission, workbook, terra_client):
     with NamedTemporaryFile() as spreadsheet_file:
         workbook.save(spreadsheet_file.name)
         project_metadata = MetadataResource.from_dict(project)
-        file_metadata = exporter.create_supplementary_file_metadata(spreadsheet_file, project_metadata)
+        file_metadata = exporter.create_supplementary_file_metadata(spreadsheet_file, project_metadata, submission['uuid']['uuid'])
         check_file_metadata(project_metadata=project_metadata, file_metadata=file_metadata, terra_client=terra_client)
 
 

--- a/tests/exporter/terra/spreadsheet/test_exporter.py
+++ b/tests/exporter/terra/spreadsheet/test_exporter.py
@@ -16,7 +16,7 @@ from exporter.schema.resource import SchemaResource
 from exporter.terra.spreadsheet.exporter import SpreadsheetExporter
 from exporter.terra.storage import TerraStorageClient
 
-MetadataFile = namedtuple('MetadataFile', ['uuid', 'filename_prefix', 'filename_suffix', 'data_uuid'])
+MetadataFile = namedtuple('MetadataFile', ['uuid', 'filename_uuid_or_shortname', 'filename_dcp_version', 'data_uuid'])
 
 
 @pytest.fixture
@@ -171,15 +171,15 @@ def test_spreadsheet_metadata_entity(supplementary_file):
     pass
 
 
-def test_filenames_differ_with_changed_dcp_version(supplementary_file, updated_supplementary_file):
+def test_metadata_uuids_match_with_changed_dcp_version(supplementary_file, updated_supplementary_file):
     initial = get_file_info(supplementary_file)
     updated = get_file_info(updated_supplementary_file)
 
     assert_that(initial.uuid).is_equal_to(updated.uuid)
     assert_that(initial.data_uuid).is_equal_to(updated.data_uuid)
-    assert_that(initial.filename_prefix).is_equal_to(updated.filename_prefix)
 
-    assert_that(initial.filename_suffix).is_not_equal_to(updated.filename_suffix)
+    assert_that(initial.filename_uuid_or_shortname).is_equal_to(updated.filename_uuid_or_shortname)
+    assert_that(initial.filename_dcp_version).is_not_equal_to(updated.filename_dcp_version)
 
 
 def test_metadata_uuids_differ_with_new_submission(supplementary_file, new_supplementary_file):
@@ -189,7 +189,8 @@ def test_metadata_uuids_differ_with_new_submission(supplementary_file, new_suppl
     assert_that(initial.uuid).is_not_equal_to(new.uuid)
     assert_that(initial.data_uuid).is_not_equal_to(new.data_uuid)
 
-    assert_that(initial.filename_prefix).is_equal_to(new.filename_prefix)
+    assert_that(initial.filename_uuid_or_shortname).is_equal_to(new.filename_uuid_or_shortname)
+    assert_that(initial.filename_dcp_version).is_not_equal_to(new.filename_dcp_version)
 
 
 def check_spreadsheet_copied_to_terra(actual_file_metadata: MetadataResource,

--- a/tests/exporter/terra/spreadsheet/test_exporter.py
+++ b/tests/exporter/terra/spreadsheet/test_exporter.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, ANY
 import pytest
 from assertpy import assert_that
 from hca_ingest.api.ingestapi import IngestApi
+from hca_ingest.utils.date import date_to_json_string, parse_date_string
 from openpyxl.workbook import Workbook
 
 from exporter.ingest.service import IngestService
@@ -83,7 +84,7 @@ def project(project_dict) -> MetadataResource:
 
 @pytest.fixture
 def updated_project(project_dict) -> MetadataResource:
-    project_dict['dcpVersion'] = datetime.utcnow().isoformat() + 'Z'
+    project_dict['dcpVersion'] = date_to_json_string(datetime.utcnow())
     return MetadataResource.from_dict(project_dict)
 
 
@@ -231,7 +232,7 @@ def check_file_metadata(project_metadata: MetadataResource, terra_client=None, f
     assert_that(filename) \
         .starts_with(short_name if short_name else project_metadata.uuid) \
         .contains('_metadata_') \
-        .contains(datetime.fromisoformat(file_metadata.dcp_version.removesuffix('Z')).strftime('%d-%m-%Y')) \
+        .contains(parse_date_string(file_metadata.dcp_version).strftime('%d-%m-%Y')) \
         .ends_with('.xlsx')
     TerraStorageClient.validate_json_doc(file_metadata.get_content())
     TerraStorageClient.update_schema_info_and_validate(


### PR DESCRIPTION
GitHub: ebi-ait/dcp-ingest-central#873
ZenHub: dcp-873

- [x] Change the spreadsheet name to `{project_shortname}_metadata_{dd}-{mm}-{yyyy}.xlsx`
- [x] Change how the metadata and datafile uuids are generated to keep them consistent across multiple exports
- [x] Seed the uuid's from the submission_uuid for quick/easy multi submission support 