### PR TITLE
dcp-873 Base dcpVersion on Export Date and allow re-exports

### DIFF
--- a/exporter/ingest/export_job.py
+++ b/exporter/ingest/export_job.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass, InitVar, field
+from datetime import datetime
 from enum import Enum
 from typing import Dict, List
+
+from hca_ingest.utils.date import parse_date_string
 
 
 @dataclass
@@ -50,13 +53,15 @@ class ExportContextState(Enum):
 class ExportJob:
     job: InitVar[dict]
     job_id: str = field(init=False)
-    num_expected_assays: int = field(init=False, default=0)
+    created_date: datetime = field(init=False)
     export_state: ExportJobState = field(init=False)
+    num_expected_assays: int = field(init=False, default=0)
     data_file_transfer: ExportContextState = field(init=False, default=ExportContextState.NOT_STARTED)
     spreadsheet_generation: ExportContextState = field(init=False, default=ExportContextState.NOT_STARTED)
 
     def __post_init__(self, job: dict):
         self.job_id = str(job["_links"]["self"]["href"]).split("/")[-1]
+        self.created_date = parse_date_string(job["createdDate"])
         self.export_state = ExportJobState(job["status"].upper())
         if 'context' in job:
             if 'totalAssayCount' in job['context']:

--- a/exporter/ingest/service.py
+++ b/exporter/ingest/service.py
@@ -66,13 +66,12 @@ class IngestService:
         find_entities_by_status_url = f'{entities_url}?status={ExportJobState.EXPORTED.value}'
         return int(self.api.get(find_entities_by_status_url).json()["page"]["totalElements"])
 
-    def set_data_file_transfer(self, export_job_id: str, state: ExportContextState):
-        self.__set_export_job_context_state(export_job_id, "dataFileTransfer", state)
+    def set_data_file_transfer(self, export_job_id: str, state: ExportContextState) -> ExportJob:
+        return self.__set_export_job_context_state(export_job_id, "dataFileTransfer", state)
 
-    def set_spreadsheet_generation(self, export_job_id: str, state: ExportContextState):
-        self.__set_export_job_context_state(export_job_id, "spreadsheetGeneration", state)
+    def set_spreadsheet_generation(self, export_job_id: str, state: ExportContextState) -> ExportJob:
+        return self.__set_export_job_context_state(export_job_id, "spreadsheetGeneration", state)
 
-    def __set_export_job_context_state(self, job_id: str, context: str, state: ExportContextState):
+    def __set_export_job_context_state(self, job_id: str, context: str, state: ExportContextState) -> ExportJob:
         job_url = self.get_job_url(job_id)
-        self.api.patch(f'{job_url}/context', json={context: state.value})
-
+        return self.api.patch(f'{job_url}/context', json={context: state.value}).json()

--- a/exporter/terra/spreadsheet/exporter.py
+++ b/exporter/terra/spreadsheet/exporter.py
@@ -41,7 +41,8 @@ class SpreadsheetExporter:
         spreadsheet_file.seek(0)
         self.terra.write_to_staging_bucket(
             object_key=f'{project_meta.uuid}/data/{file_meta.full_resource["fileName"]}',
-            data_stream=spreadsheet_file
+            data_stream=spreadsheet_file,
+            overwrite=True
         )
 
     def write_links(self, file_meta: Metadata, project_meta: Metadata):

--- a/exporter/terra/spreadsheet/handler.py
+++ b/exporter/terra/spreadsheet/handler.py
@@ -29,8 +29,8 @@ class SpreadsheetHandler(MessageHandler):
     def handle_message(self, body: dict, msg: Message):
         message = SpreadsheetExporterMessage(body)
         self.logger.info('Received spreadsheet export message, informing ingest')
-        self.ingest.set_spreadsheet_generation(message.job_id, ExportContextState.STARTED)
-        self.exporter.export_spreadsheet(message.project_uuid, message.submission_uuid)
+        export_job = self.ingest.set_spreadsheet_generation(message.job_id, ExportContextState.STARTED)
+        self.exporter.export_spreadsheet(message.project_uuid, message.submission_uuid, export_job.created_date)
         self.logger.info('Spreadsheet export finished, informing ingest')
         self.ingest.set_spreadsheet_generation(message.job_id, ExportContextState.COMPLETE)
         self.logger.info('Acknowledging spreadsheet export message')

--- a/exporter/terra/storage.py
+++ b/exporter/terra/storage.py
@@ -65,10 +65,10 @@ class TerraStorageClient:
         TerraStorageClient.update_schema_info_and_validate(json_doc, latest_schema)
         return json_doc
 
-    def write_to_staging_bucket(self, object_key: str, data_stream: Streamable):
+    def write_to_staging_bucket(self, object_key: str, data_stream: Streamable, overwrite=False):
         file_key = f"{self.key_prefix}/{object_key}"
-        self.logger.info(f'Writing file: {file_key}')
-        self.gcs_storage.write(self.bucket_name, file_key, data_stream)
+        self.logger.info(f'{"Overwriting" if overwrite else "Writing"} file: {file_key}')
+        self.gcs_storage.write(self.bucket_name, file_key, data_stream, overwrite)
 
     def generate_links_json(self, link_set: LinkSet) -> Dict:
         json_doc = link_set.to_dict()

--- a/tests/exporter/terra/spreadsheet/test_exporter.py
+++ b/tests/exporter/terra/spreadsheet/test_exporter.py
@@ -17,7 +17,7 @@ from exporter.schema.resource import SchemaResource
 from exporter.terra.spreadsheet.exporter import SpreadsheetExporter
 from exporter.terra.storage import TerraStorageClient
 
-MetadataFile = namedtuple('MetadataFile', ['uuid', 'filename_uuid_or_shortname', 'filename_dcp_version', 'data_uuid'])
+MetadataFile = namedtuple('MetadataFile', ['uuid', 'filename_uuid_or_shortname', 'data_uuid'])
 
 
 @pytest.fixture
@@ -33,6 +33,11 @@ def ingest_api(mocker, submission_dict, project_dict):
     ingest_api.get_latest_schema_url.return_value = 'https://schema.humancellatlas.org/type/file/2.5.0/supplementary_file'
     ingest_api.get_entity_by_uuid.return_value = project_dict
     return ingest_api
+
+
+@pytest.fixture
+def export_date():
+    return datetime.now()
 
 
 @pytest.fixture
@@ -89,18 +94,18 @@ def updated_project(project_dict) -> MetadataResource:
 
 
 @pytest.fixture
-def supplementary_file(exporter, project, submission_uuid, terra_client):
-    return create_supplementary_file(exporter, project, submission_uuid, terra_client)
+def supplementary_file(terra_client, exporter, project, submission_uuid, export_date):
+    return create_supplementary_file(terra_client, exporter, project, submission_uuid, export_date)
 
 
 @pytest.fixture
-def updated_supplementary_file(exporter, updated_project, submission_uuid, terra_client):
-    return create_supplementary_file(exporter, updated_project, submission_uuid, terra_client)
+def updated_supplementary_file(terra_client, exporter, updated_project, submission_uuid, export_date):
+    return create_supplementary_file(terra_client, exporter, updated_project, submission_uuid, export_date)
 
 
 @pytest.fixture
-def new_supplementary_file(exporter, updated_project, new_submission_uuid, terra_client):
-    return create_supplementary_file(exporter, updated_project, new_submission_uuid, terra_client)
+def new_supplementary_file(terra_client, exporter, updated_project, new_submission_uuid, export_date):
+    return create_supplementary_file(terra_client, exporter, updated_project, new_submission_uuid, export_date)
 
 
 @pytest.fixture
@@ -133,38 +138,38 @@ def failing_exporter(ingest_service, terra_client, mocker):
 def test_happy_path(exporter: SpreadsheetExporter,
                     ingest_service: Mock,
                     terra_client: Mock,
-                    project,
-                    submission_uuid,
+                    project: MetadataResource,
+                    submission_uuid: str,
+                    export_date: datetime,
                     caplog):
     # given
     # uses an exporter fixture
 
     # when
-    exporter.export_spreadsheet(project_uuid=project.uuid,
-                                submission_uuid=submission_uuid)
+    exporter.export_spreadsheet(project.uuid, submission_uuid, export_date)
 
     # then
-    actual_file_metadata = check_file_metadata(project, terra_client)
-    check_generated_links(actual_file_metadata, project, terra_client)
+    actual_file_metadata = check_file_metadata(project, terra_client=terra_client)
+    check_generated_links(terra_client, project, actual_file_metadata, export_date)
     check_spreadsheet_copied_to_terra(actual_file_metadata, project, terra_client)
     assert "Generating Spreadsheet" in caplog.text
 
 
-def test_exception_during_export(failing_exporter: SpreadsheetExporter, project_uuid, submission_uuid, caplog):
+def test_exception_during_export(failing_exporter: SpreadsheetExporter, project_uuid, submission_uuid, export_date: datetime, caplog):
     # given an exception is thrown while generating the spreadsheet
 
     # when
     with pytest.raises(RuntimeError):
-        failing_exporter.export_spreadsheet(project_uuid=project_uuid,
-                                            submission_uuid=submission_uuid)
+        failing_exporter.export_spreadsheet(project_uuid, submission_uuid, export_date)
 
 
-def create_supplementary_file(exporter, project, submission_uuid, terra_client):
+def create_supplementary_file(terra_client, exporter, project, submission_uuid, export_date):
     with NamedTemporaryFile() as spreadsheet_file:
         file = exporter.create_supplementary_file_metadata(spreadsheet_file,
                                                            project,
-                                                           submission_uuid)
-        check_file_metadata(project, terra_client, file)
+                                                           submission_uuid,
+                                                           export_date)
+        check_file_metadata(project, file, terra_client)
         return file
 
 
@@ -172,26 +177,18 @@ def test_spreadsheet_metadata_entity(supplementary_file):
     pass
 
 
-def test_metadata_uuids_match_with_changed_dcp_version(supplementary_file, updated_supplementary_file):
+def test_metadata_uuids_match_with_updated_submission(supplementary_file, updated_supplementary_file):
     initial = get_file_info(supplementary_file)
     updated = get_file_info(updated_supplementary_file)
 
-    assert_that(initial.uuid).is_equal_to(updated.uuid)
-    assert_that(initial.data_uuid).is_equal_to(updated.data_uuid)
-
-    assert_that(initial.filename_uuid_or_shortname).is_equal_to(updated.filename_uuid_or_shortname)
-    assert_that(initial.filename_dcp_version).is_not_equal_to(updated.filename_dcp_version)
+    assert_that(initial).is_equal_to(updated)
 
 
 def test_metadata_uuids_differ_with_new_submission(supplementary_file, new_supplementary_file):
     initial = get_file_info(supplementary_file)
     new = get_file_info(new_supplementary_file)
 
-    assert_that(initial.uuid).is_not_equal_to(new.uuid)
-    assert_that(initial.data_uuid).is_not_equal_to(new.data_uuid)
-
-    assert_that(initial.filename_uuid_or_shortname).is_equal_to(new.filename_uuid_or_shortname)
-    assert_that(initial.filename_dcp_version).is_not_equal_to(new.filename_dcp_version)
+    assert_that(initial).is_not_equal_to(new)
 
 
 def check_spreadsheet_copied_to_terra(actual_file_metadata: MetadataResource,
@@ -202,18 +199,16 @@ def check_spreadsheet_copied_to_terra(actual_file_metadata: MetadataResource,
     )
 
 
-def check_generated_links(actual_file_metadata: MetadataResource,
-                          project_metadata: MetadataResource | dict,
-                          terra_client):
-    if isinstance(project_metadata, dict):
-        project_metadata = MetadataResource.from_dict(project_metadata)
-    terra_client.write_links.assert_called_with(ANY,
-                                                actual_file_metadata.uuid,
-                                                project_metadata.dcp_version,
-                                                project_metadata.uuid)
+def check_generated_links(terra_client, project_metadata: MetadataResource, file_metadata: MetadataResource, export_date: datetime):
+    terra_client.write_links.assert_called_with(
+        ANY,
+        file_metadata.uuid,
+        date_to_json_string(export_date),
+        project_metadata.uuid,
+    )
 
 
-def check_file_metadata(project_metadata: MetadataResource, terra_client=None, file_metadata=None):
+def check_file_metadata(project_metadata: MetadataResource, file_metadata=None, terra_client=None) -> MetadataResource:
     if terra_client and not file_metadata:
         terra_client.write_metadata.assert_called_with(ANY, project_metadata.uuid)
         if file_metadata:
@@ -244,4 +239,4 @@ def check_file_metadata(project_metadata: MetadataResource, terra_client=None, f
 def get_file_info(file: MetadataResource) -> MetadataFile:
     filename = file.full_resource['fileName']
     name_split = filename.split('_metadata_')
-    return MetadataFile(file.uuid, name_split[0],  name_split[1], file.full_resource['dataFileUuid'])
+    return MetadataFile(file.uuid, name_split[0], file.full_resource['dataFileUuid'])

--- a/tests/exporter/terra/spreadsheet/test_exporter.py
+++ b/tests/exporter/terra/spreadsheet/test_exporter.py
@@ -195,7 +195,8 @@ def check_spreadsheet_copied_to_terra(actual_file_metadata: MetadataResource,
                                       project: MetadataResource, terra_client):
     terra_client.write_to_staging_bucket.assert_called_with(
         object_key=f'{project.uuid}/data/{actual_file_metadata.full_resource["fileName"]}',
-        data_stream=ANY
+        data_stream=ANY,
+        overwrite=True
     )
 
 


### PR DESCRIPTION
GitHub: ebi-ait/dcp-ingest-central#873
ZenHub: dcp-873

- [x] Create a synthetic `dcpVersion` based on the export date
- [x] Allow overwrites for spreadsheets (to allow multiple exports on the same day)
