### PR TITLE
dcp-873 Use spreadsheet dcp version from submission contentLastUpdated

### DIFF
--- a/exporter/ingest/service.py
+++ b/exporter/ingest/service.py
@@ -55,6 +55,14 @@ class IngestService:
     def get_submission(self, submission_uuid):
         return self.api.get_submission_by_uuid(submission_uuid)
 
+    def get_submission_dcp_version_from_uuid(self, submission_uuid: str) -> str:
+        submission = self.get_submission(submission_uuid)
+        return self.get_submission_dcp_version(submission)
+
+    def get_submission_dcp_version(self, submission: dict) -> str:
+        url = self.api.get_link_from_resource(submission, 'contentLastUpdated')
+        return self.api.get(url).json()
+
     def project_for_process(self, process: MetadataResource) -> MetadataResource:
         return MetadataResource.from_dict(list(self.api.get_related_entities(
             "projects",

--- a/exporter/ingest/service.py
+++ b/exporter/ingest/service.py
@@ -82,4 +82,5 @@ class IngestService:
 
     def __set_export_job_context_state(self, job_id: str, context: str, state: ExportContextState) -> ExportJob:
         job_url = self.get_job_url(job_id)
-        return self.api.patch(f'{job_url}/context', json={context: state.value}).json()
+        job_json = self.api.patch(f'{job_url}/context', json={context: state.value}).json()
+        return ExportJob(job_json)

--- a/exporter/terra/spreadsheet/handler.py
+++ b/exporter/terra/spreadsheet/handler.py
@@ -29,8 +29,8 @@ class SpreadsheetHandler(MessageHandler):
     def handle_message(self, body: dict, msg: Message):
         message = SpreadsheetExporterMessage(body)
         self.logger.info('Received spreadsheet export message, informing ingest')
-        export_job = self.ingest.set_spreadsheet_generation(message.job_id, ExportContextState.STARTED)
-        self.exporter.export_spreadsheet(message.project_uuid, message.submission_uuid, export_job.created_date)
+        self.ingest.set_spreadsheet_generation(message.job_id, ExportContextState.STARTED)
+        self.exporter.export_spreadsheet(message.project_uuid, message.submission_uuid)
         self.logger.info('Spreadsheet export finished, informing ingest')
         self.ingest.set_spreadsheet_generation(message.job_id, ExportContextState.COMPLETE)
         self.logger.info('Acknowledging spreadsheet export message')


### PR DESCRIPTION
GitHub: ebi-ait/dcp-ingest-central#873
ZenHub: dcp-873

- [x] Use spreadsheet dcp version from submission contentLastUpdated
- [x] Resolve `'dict' object has no attribute 'created_date'` issue, that was introduced in #49