### PR TITLE
dcp-873 filter deleted submissions

### DIFF
--- a/docs/requeue_errors.py
+++ b/docs/requeue_errors.py
@@ -1,0 +1,21 @@
+from kombu import Connection, Exchange, Queue, Consumer, Message, Producer
+
+exchange = Exchange('ingest.exporter.exchange', type="topic")
+error_queue = Queue(name='ingest.exporter.errored.queue', exchange=exchange, routing_key='ingest.terra.spreadsheet.error')
+conn = Connection("amqp://localhost:5672/")
+with conn.channel() as channel:
+    def process_errors(body: str, message: Message):
+        routing_key = message.headers.get('x-death', [{}])[0].get('routing-keys', [''])[0]
+        if routing_key:
+            print(f"message re-published to {routing_key}: {body}")
+            producer = Producer(exchange=exchange, channel=channel, routing_key=routing_key)
+            producer.publish(body)
+            message.ack()
+        else:
+            print(f"message rejected, no routing key: {body}")
+            message.reject(requeue=True)
+
+    with Consumer(conn, queues=error_queue, callbacks=[process_errors], accept=["application/json;charset=UTF-8"]):
+        conn.drain_events(timeout=10)
+
+    channel.close()

--- a/exporter/ingest/service.py
+++ b/exporter/ingest/service.py
@@ -38,10 +38,10 @@ class IngestService:
         job_url = self.get_job_url(job_id)
         return ExportJob(self.api.get(job_url).json())
 
-    def job_exists(self, job_id: str) -> bool:
-        job_url = self.get_job_url(job_id)
-        response = self.api.session.get(job_url, headers=self.api.get_headers())
-        return response.ok
+    def job_exists_with_submission(self, job_id) -> bool:
+        job_dict = self.__get_job_if_exists(job_id)
+        submission_link = self.api.get_link_from_resource(job_dict, "submission")
+        return submission_link and not submission_link.endswith('/submissionEnvelopes')
 
     def get_job_url(self, job_id: str) -> str:
         return self.api.get_full_url(f'/exportJobs/{job_id}')
@@ -84,3 +84,10 @@ class IngestService:
         job_url = self.get_job_url(job_id)
         job_json = self.api.patch(f'{job_url}/context', json={context: state.value}).json()
         return ExportJob(job_json)
+
+    def __get_job_if_exists(self, job_id: str):
+        job_url = self.get_job_url(job_id)
+        response = self.api.session.get(job_url, headers=self.api.get_headers())
+        if response.ok:
+            return response.json()
+        return {}

--- a/exporter/terra/submission/responder.py
+++ b/exporter/terra/submission/responder.py
@@ -56,7 +56,7 @@ class TerraTransferResponder:
                 return message.nack()
             self.handle_data_transfer_complete(message, export_job_id)
 
-    def hande_data_transfer_complete(self, message: Message, export_job_id: str):
+    def handle_data_transfer_complete(self, message: Message, export_job_id: str):
         self.logger.info(f'Received message that data transfer is complete, informing ingest')
         self.ingest.set_data_file_transfer(export_job_id, ExportContextState.COMPLETE)
         self.logger.info(f'Acknowledging data transfer complete message')

--- a/exporter/terra/submission/responder.py
+++ b/exporter/terra/submission/responder.py
@@ -50,10 +50,10 @@ class TerraTransferResponder:
             self.logger.error(f'Could not parse message: {message.attributes}')
             return message.nack()
         export_job_id = transfer_name.replace('transferJobs/', '')
-        if not self.ingest.job_exists(export_job_id):
-            self.logger.warning(f'Job does not exist on this environment, this could be because the terra staging environment is used for both dev and staging ingest: {export_job_id}')
-            return message.nack()
         with SessionContext(logger=self.logger, context={'export_job_id': export_job_id}):
+            if not self.ingest.job_exists_with_submission(export_job_id):
+                self.logger.warning(f'Job or submission does not exist on this environment.')
+                return message.nack()
             self.hande_data_transfer_complete(message, export_job_id)
 
     def hande_data_transfer_complete(self, message: Message, export_job_id: str):

--- a/exporter/terra/submission/responder.py
+++ b/exporter/terra/submission/responder.py
@@ -54,7 +54,7 @@ class TerraTransferResponder:
             if not self.ingest.job_exists_with_submission(export_job_id):
                 self.logger.warning(f'Job or submission does not exist on this environment.')
                 return message.nack()
-            self.hande_data_transfer_complete(message, export_job_id)
+            self.handle_data_transfer_complete(message, export_job_id)
 
     def hande_data_transfer_complete(self, message: Message, export_job_id: str):
         self.logger.info(f'Received message that data transfer is complete, informing ingest')


### PR DESCRIPTION
GitHub: ebi-ait/dcp-ingest-central#873
ZenHub: dcp-873

- [x] filter google transfer notifications for deleted submissions
- [x] script to re-queue errors in the error queue to their original queues.
    - Helpful when errors occur in lots of places.